### PR TITLE
fix(host): keep Local Whisper state responses JSON-safe

### DIFF
--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -52,6 +52,8 @@ interface FailureEntry {
   until: number
 }
 
+// Keep optional error fields absent rather than explicitly undefined: the
+// typert gateway checks every own enumerable result property for JSON safety.
 const EMPTY_STATE: WhisperModelState = Object.freeze({
   cliAvailable: false,
   downloaded: false,
@@ -59,9 +61,7 @@ const EMPTY_STATE: WhisperModelState = Object.freeze({
   progress: null,
   bytes: null,
   totalBytes: null,
-  error: null,
-  errorCode: undefined,
-  errorParams: undefined
+  error: null
 })
 
 export interface WhisperModelsOptions {
@@ -468,7 +468,12 @@ export class WhisperModels {
     ].join('\n')
     const promise = (async () => {
       const output = await this.runPythonCollect(python, ['-c', script], STATE_COMMAND_TIMEOUT_MS)
-      const parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+      let parsed: { root?: unknown; files?: unknown }
+      try {
+        parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+      } catch {
+        throw new Error('The installed whisper returned an unreadable model table')
+      }
       if (typeof parsed.root !== 'string' || typeof parsed.files !== 'object' || parsed.files === null) {
         throw new Error('Could not read the installed whisper model table')
       }

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -468,21 +468,25 @@ export class WhisperModels {
     ].join('\n')
     const promise = (async () => {
       const output = await this.runPythonCollect(python, ['-c', script], STATE_COMMAND_TIMEOUT_MS)
-      let parsed: { root?: unknown; files?: unknown }
+      let parsed: unknown
       try {
-        parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+        parsed = JSON.parse(output.trim())
       } catch {
         throw new Error('The installed whisper returned an unreadable model table')
       }
-      if (typeof parsed.root !== 'string' || typeof parsed.files !== 'object' || parsed.files === null) {
+      if (parsed === null || typeof parsed !== 'object') {
+        throw new Error('The installed whisper returned an unreadable model table')
+      }
+      const { root, files: rawFiles } = parsed as { root?: unknown; files?: unknown }
+      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null) {
         throw new Error('Could not read the installed whisper model table')
       }
       const files = new Map<string, string>()
-      for (const [name, file] of Object.entries(parsed.files as Record<string, unknown>)) {
+      for (const [name, file] of Object.entries(rawFiles as Record<string, unknown>)) {
         if (typeof file === 'string') files.set(name, file)
       }
       if (files.size === 0) throw new Error('The installed whisper exposes no models')
-      return { root: parsed.root, files }
+      return { root, files }
     })()
     this.modelTablePromise = promise
     try {

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -478,7 +478,7 @@ export class WhisperModels {
         throw new Error('The installed whisper returned an unreadable model table')
       }
       const { root, files: rawFiles } = parsed as { root?: unknown; files?: unknown }
-      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null) {
+      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null || Array.isArray(rawFiles)) {
         throw new Error('Could not read the installed whisper model table')
       }
       const files = new Map<string, string>()

--- a/tests/asr-backends.test.ts
+++ b/tests/asr-backends.test.ts
@@ -23,7 +23,9 @@ describe('local Whisper backend', () => {
     await expect(isWhisperAvailable(process.execPath, controller.signal)).resolves.toBe(false)
   })
 
-  it('writes a private temporary audio file and reads the Whisper JSON result', async () => {
+  // These fixtures are POSIX shebang scripts. Native Windows production
+  // installs use a real whisper.exe, so only the fixture-based cases skip.
+  it.skipIf(process.platform === 'win32')('writes a private temporary audio file and reads the Whisper JSON result', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nimport { writeFile } from \'node:fs/promises\'\nimport { join } from \'node:path\'\nconst index = process.argv.indexOf(\'--output_dir\')\nawait writeFile(join(process.argv[index + 1], \'recording.json\'), JSON.stringify({ text: \'本地转录结果\' }))\n')
@@ -42,7 +44,7 @@ describe('local Whisper backend', () => {
     }
   })
 
-  it('carries the whisper stderr tail into transcription failures', async () => {
+  it.skipIf(process.platform === 'win32')('carries the whisper stderr tail into transcription failures', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nprocess.stderr.write(\'Traceback (most recent call last):\\nRuntimeError: model not found\\n\')\nprocess.exit(1)\n')
@@ -61,7 +63,7 @@ describe('local Whisper backend', () => {
     }
   })
 
-  it('preserves the timeout error code when Whisper is aborted by its deadline', async () => {
+  it.skipIf(process.platform === 'win32')('preserves the timeout error code when Whisper is aborted by its deadline', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nsetInterval(() => {}, 1000)\n')

--- a/tests/whisper-model-state-wire.test.ts
+++ b/tests/whisper-model-state-wire.test.ts
@@ -1,0 +1,68 @@
+import { dirname } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { WhisperModels, type WhisperModelState } from '../src/asr/whisper-models.js'
+import { whisperModelStateSchema } from '../src/remote-contract.js'
+
+/**
+ * Reproduce the dsh-api-gateway strict result check: the zod parse of a
+ * strict result must keep every own enumerable property JSON-safe. Optional
+ * keys that arrive with an `undefined` value survive the parse as own
+ * properties, so the gateway rejects the business result
+ * ("business result failed boundary validation") even though the schema
+ * accepted it: a WhisperModelState must never carry an `undefined` value.
+ */
+function assertGatewayWireSafe(state: unknown): void {
+  const parsed = whisperModelStateSchema.parse(state)
+  const walk = (value: unknown): void => {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) throw new Error('non-finite number is not JSON-safe')
+      return
+    }
+    if (typeof value !== 'object' || value === null) throw new Error(`${typeof value} is not JSON-safe`)
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      if (item === undefined) throw new Error(`${key} is not JSON-safe`)
+      walk(item)
+    }
+  }
+  walk(parsed)
+}
+
+describe('whisper model state wire safety', () => {
+  it('returns gateway-safe states on every no-interpreter path', async () => {
+    // Keep PATH to the Node directory only: this prevents a real whisper or
+    // Python installation from making the test depend on the host machine.
+    const manager = new WhisperModels({ env: { ...process.env, PATH: dirname(process.execPath) } })
+    try {
+      const states: WhisperModelState[] = [
+        await manager.getWhisperModelState('tiny', false),
+        await manager.getWhisperModelState('tiny', true),
+        await manager.downloadWhisperModel('tiny', false),
+        await manager.downloadWhisperModel('tiny', true),
+        await manager.cancelWhisperModelDownload('tiny', false),
+        await manager.deleteWhisperModel('tiny', true)
+      ]
+      for (const state of states) {
+        expect(state.cliAvailable).toBeTypeOf('boolean')
+        expect(() => assertGatewayWireSafe(state)).not.toThrow()
+      }
+      manager.dispose()
+      const disposed = await manager.getWhisperModelState('tiny', false)
+      expect(() => assertGatewayWireSafe(disposed)).not.toThrow()
+    } finally {
+      manager.dispose()
+    }
+  })
+
+  it('keeps the downloaded-state shape gateway-safe', () => {
+    expect(() => assertGatewayWireSafe({
+      cliAvailable: true,
+      downloaded: true,
+      downloading: false,
+      progress: null,
+      bytes: null,
+      totalBytes: 100,
+      error: null
+    })).not.toThrow()
+  })
+})

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -93,6 +93,7 @@ const FAKE_PYTHON_SCRIPT = [
   "if (script.includes('print(json.dumps')) {",
   "  if (process.env.FAKE_WHISPER_BAD_TABLE === '1') { process.stdout.write('not json\\n'); process.exit(0) }",
   "  if (process.env.FAKE_WHISPER_NULL_TABLE === '1') { process.stdout.write('null\\n'); process.exit(0) }",
+  "  if (process.env.FAKE_WHISPER_ARRAY_TABLE === '1') { process.stdout.write(JSON.stringify({ root: root, files: [] }) + '\\n'); process.exit(0) }",
   "  process.stdout.write(JSON.stringify({ root: root, files: { tiny: 'tiny.pt', base: 'base.pt' } }) + '\\n')",
   '  process.exit(0)',
   '}',
@@ -370,6 +371,19 @@ describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
     try {
       const state = await manager.getWhisperModelState('tiny', true)
       expect(state.error).toContain('unreadable model table')
+      expect(state.errorCode).toBe('whisper.stateQueryFailed')
+    } finally {
+      manager.dispose()
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an array-valued model table files field', async () => {
+    const { cacheDir, env } = await makeEnv({ FAKE_WHISPER_ARRAY_TABLE: '1' })
+    const manager = new WhisperModels({ env })
+    try {
+      const state = await manager.getWhisperModelState('tiny', true)
+      expect(state.error).toContain('Could not read the installed whisper model table')
       expect(state.errorCode).toBe('whisper.stateQueryFailed')
     } finally {
       manager.dispose()

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -121,7 +121,13 @@ const FAKE_PYTHON_SCRIPT = [
   ''
 ].join('\n')
 
-describe('whisper model lifecycle', () => {
+/**
+ * The fake python is a POSIX shebang script; native Windows cannot spawn it
+ * (CreateProcess requires a real PE executable), so the spawn-based lifecycle
+ * suite runs only where the kernel handles the shebang. Platform-independent
+ * coverage remains in the discovery and progress-parsing suites.
+ */
+describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
   let binDir: string
   let baseEnv: NodeJS.ProcessEnv
 

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -92,6 +92,7 @@ const FAKE_PYTHON_SCRIPT = [
   '}',
   "if (script.includes('print(json.dumps')) {",
   "  if (process.env.FAKE_WHISPER_BAD_TABLE === '1') { process.stdout.write('not json\\n'); process.exit(0) }",
+  "  if (process.env.FAKE_WHISPER_NULL_TABLE === '1') { process.stdout.write('null\\n'); process.exit(0) }",
   "  process.stdout.write(JSON.stringify({ root: root, files: { tiny: 'tiny.pt', base: 'base.pt' } }) + '\\n')",
   '  process.exit(0)',
   '}',
@@ -357,6 +358,19 @@ describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
       const second = await manager.getWhisperModelState('tiny', true)
       expect(second.error).toBe(first.error)
       expect(await probeCount()).toBe(afterFirst)
+    } finally {
+      manager.dispose()
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a null model table with a controlled state error', async () => {
+    const { cacheDir, env } = await makeEnv({ FAKE_WHISPER_NULL_TABLE: '1' })
+    const manager = new WhisperModels({ env })
+    try {
+      const state = await manager.getWhisperModelState('tiny', true)
+      expect(state.error).toContain('unreadable model table')
+      expect(state.errorCode).toBe('whisper.stateQueryFailed')
     } finally {
       manager.dispose()
       await rm(cacheDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Local Whisper model-state responses now cross the Typert Remote boundary when the host has no usable Whisper interpreter.

## Root cause

The empty `WhisperModelState` included optional `errorCode` and `errorParams` properties with the value `undefined`. The Typert gateway’s strict result path preserves those optional properties during zod parsing and then checks every own enumerable property for JSON safety. The resulting `undefined is not JSON-safe` failure was surfaced as `business result failed boundary validation`.

## Changes

- Keep optional error fields absent from the empty state.
- Turn unreadable model-table output into a descriptive state-query error.
- Add a regression suite that validates every empty, disposed, and downloaded state against the strict Remote schema and JSON-safety contract.
- Scope synthetic POSIX shebang fixtures to POSIX hosts; native Windows continues to run the platform-independent discovery, progress, and Remote wire-safety coverage. Real Windows Whisper installations use their native executable path.

## Verification

- `tsc --noEmit`: passed.
- Linux worktree with pnpm `11.19.0`: 28 test files and 286 tests passed.
- The regression suite runs with an isolated PATH containing only the Node directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable or invalid model-table data with clearer error reporting.
  * Improved Whisper model status responses to ensure they remain safe and valid for gateway communication.
  * Prevented unsupported platform-specific test fixtures from running on Windows.

* **Tests**
  * Added coverage for model lifecycle states, disposed managers, downloaded models, invalid model tables, and JSON-safe status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->