### PR TITLE
chore(dev): separate native dependency trees by platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.19.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm use:platform
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+node_modules.*
 dist/
 lib/
 .dsh/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ After a clone, start here. Product scope and still-open gates are in [`.agent/PL
 ```sh
 git clone https://github.com/WizisCool/dsh-ears.git
 cd dsh-ears
+pnpm use:platform
 pnpm install
 pnpm check
 pnpm test
@@ -28,6 +29,21 @@ dsh plugin --profile web add "$PWD"
 ```
 
 On Windows, run this from PowerShell or Git Bash — `cmd.exe` does not expand `$PWD`; use `"%CD%"` from cmd.
+
+## Cross-platform installs
+
+The checkout keeps native dependency trees in separate directories: `node_modules.win32` for Windows and `node_modules.linux` for WSL. The active tree is exposed as `node_modules`, so each platform keeps its own native packages and command shims.
+
+After switching between PowerShell and WSL:
+
+```sh
+pnpm use:platform
+pnpm install
+```
+
+Run `pnpm use:platform` before the first install on a fresh clone and after stopping any dev server that still holds the active dependency tree open. The selector preserves the previous platform tree and creates the new platform tree when needed. Both environments use pnpm `11.19.0` from `packageManager`.
+
+Spawn-based local Whisper fixtures are POSIX shebang scripts; native Windows skips those fixture cases while still running discovery, progress-parsing, and Remote wire-safety tests.
 
 If `dsh` is not on `PATH`:
 

--- a/README.en.md
+++ b/README.en.md
@@ -52,6 +52,7 @@ npx -y @deepseek-ai/dsh plugin --profile web add dsh-ears
 ```sh
 git clone https://github.com/WizisCool/dsh-ears.git
 cd dsh-ears
+pnpm use:platform
 pnpm install
 pnpm build
 dsh plugin --profile web add "$PWD"
@@ -118,6 +119,7 @@ The default prompt removes filler words, fixes common ASR errors, handles spoken
 ## Local development
 
 ```sh
+pnpm use:platform
 pnpm install
 dsh plugin --profile web add "$PWD"
 # Windows cmd: use "%CD%"; PowerShell expands $PWD directly

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ npx -y @deepseek-ai/dsh plugin --profile web add dsh-ears
 ```sh
 git clone https://github.com/WizisCool/dsh-ears.git
 cd dsh-ears
+pnpm use:platform
 pnpm install
 pnpm build
 dsh plugin --profile web add "$PWD"
@@ -106,6 +107,7 @@ npx -y @deepseek-ai/dsh plugin --profile web remove dsh-ears
 ## 本地开发
 
 ```sh
+pnpm use:platform
 pnpm install
 dsh plugin --profile web add "$PWD"
 # Windows 的 cmd 请使用 "%CD%"；PowerShell 直接使用 $PWD

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "scripts": {
     "build": "tsdown && tsc -p tsconfig.build.json",
     "check": "tsc --noEmit -p tsconfig.json",
+    "use:platform": "node scripts/select-node-modules.mjs",
     "dev:watch": "tsdown --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/select-node-modules.mjs
+++ b/scripts/select-node-modules.mjs
@@ -1,9 +1,12 @@
-import { lstat, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ACTIVE_DIRECTORY = 'node_modules'
 const MARKER_FILE = '.dsh-ears-platform'
+const PLATFORM_LOCK_FILE = 'node_modules.platform.lock'
+const LOCK_RETRY_MS = 25
+const LOCK_TIMEOUT_MS = 30_000
 const SUPPORTED_PLATFORMS = new Set(['win32', 'linux'])
 
 export function platformDirectory(platform = process.platform) {
@@ -54,15 +57,34 @@ async function assertManagedDirectory(path, expectedPlatform) {
   }
 }
 
-/**
- * Select the platform-specific dependency tree as the active node_modules
- * directory. Existing trees are moved aside rather than deleted, so switching
- * between Windows and WSL preserves each platform's native packages and
- * command shims.
- */
-export async function selectNodeModules(root = process.cwd(), platform = process.platform) {
-  const selectedPlatform = platformDirectory(platform)
-  const projectRoot = resolve(root)
+function isAlreadyExists(error) {
+  return error instanceof Error && 'code' in error && error.code === 'EEXIST'
+}
+
+async function withPlatformSelectionLock(root, callback) {
+  const lockPath = join(root, PLATFORM_LOCK_FILE)
+  const deadline = Date.now() + LOCK_TIMEOUT_MS
+  let lock
+  while (lock === undefined) {
+    try {
+      lock = await open(lockPath, 'wx')
+    } catch (error) {
+      if (!isAlreadyExists(error)) throw error
+      if (Date.now() >= deadline) {
+        throw new Error(`Could not acquire the platform selection lock at ${lockPath}`)
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS))
+    }
+  }
+  try {
+    return await callback()
+  } finally {
+    await lock.close().catch(() => undefined)
+    await rm(lockPath, { force: true })
+  }
+}
+
+async function selectNodeModulesUnlocked(projectRoot, selectedPlatform) {
   const activePath = join(projectRoot, ACTIVE_DIRECTORY)
   const selectedPath = join(projectRoot, `${ACTIVE_DIRECTORY}.${selectedPlatform}`)
   const activeInfo = await inspect(activePath)
@@ -116,6 +138,18 @@ export async function selectNodeModules(root = process.cwd(), platform = process
     throw error
   }
   return { platform: selectedPlatform, changed: true, initialized: false }
+}
+
+/**
+ * Select the platform-specific dependency tree as the active node_modules
+ * directory. Existing trees are moved aside rather than deleted, so switching
+ * between Windows and WSL preserves each platform's native packages and
+ * command shims.
+ */
+export async function selectNodeModules(root = process.cwd(), platform = process.platform) {
+  const selectedPlatform = platformDirectory(platform)
+  const projectRoot = resolve(root)
+  return withPlatformSelectionLock(projectRoot, () => selectNodeModulesUnlocked(projectRoot, selectedPlatform))
 }
 
 const invokedPath = process.argv[1] === undefined ? undefined : resolve(process.argv[1])

--- a/scripts/select-node-modules.mjs
+++ b/scripts/select-node-modules.mjs
@@ -1,0 +1,131 @@
+import { lstat, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ACTIVE_DIRECTORY = 'node_modules'
+const MARKER_FILE = '.dsh-ears-platform'
+const SUPPORTED_PLATFORMS = new Set(['win32', 'linux'])
+
+export function platformDirectory(platform = process.platform) {
+  if (!SUPPORTED_PLATFORMS.has(platform)) {
+    throw new Error(`Unsupported platform ${JSON.stringify(platform)}; use Windows or Linux/WSL.`)
+  }
+  return platform
+}
+
+async function inspect(path) {
+  try {
+    return await lstat(path)
+  } catch (error) {
+    if (isMissing(error)) return undefined
+    throw error
+  }
+}
+
+function isMissing(error) {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+async function readMarker(directory) {
+  try {
+    const platform = (await readFile(join(directory, MARKER_FILE), 'utf8')).trim()
+    if (!SUPPORTED_PLATFORMS.has(platform)) {
+      throw new Error(`Invalid ${MARKER_FILE} value in ${directory}`)
+    }
+    return platform
+  } catch (error) {
+    if (isMissing(error)) return undefined
+    throw error
+  }
+}
+
+async function writeMarker(directory, platform) {
+  await writeFile(join(directory, MARKER_FILE), `${platform}\n`, 'utf8')
+}
+
+async function assertManagedDirectory(path, expectedPlatform) {
+  const info = await inspect(path)
+  if (info === undefined || info.isSymbolicLink() || !info.isDirectory()) {
+    throw new Error(`${path} is not a managed dependency directory`)
+  }
+  const platform = await readMarker(path)
+  if (platform !== expectedPlatform) {
+    throw new Error(`${path} is not marked for ${expectedPlatform}`)
+  }
+}
+
+/**
+ * Select the platform-specific dependency tree as the active node_modules
+ * directory. Existing trees are moved aside rather than deleted, so switching
+ * between Windows and WSL preserves each platform's native packages and
+ * command shims.
+ */
+export async function selectNodeModules(root = process.cwd(), platform = process.platform) {
+  const selectedPlatform = platformDirectory(platform)
+  const projectRoot = resolve(root)
+  const activePath = join(projectRoot, ACTIVE_DIRECTORY)
+  const selectedPath = join(projectRoot, `${ACTIVE_DIRECTORY}.${selectedPlatform}`)
+  const activeInfo = await inspect(activePath)
+
+  if (activeInfo !== undefined && (activeInfo.isSymbolicLink() || !activeInfo.isDirectory())) {
+    throw new Error(`${activePath} must be a real directory before platform selection`)
+  }
+
+  if (activeInfo === undefined) {
+    const selectedInfo = await inspect(selectedPath)
+    if (selectedInfo === undefined) {
+      await mkdir(activePath, { recursive: true })
+      await writeMarker(activePath, selectedPlatform)
+      return { platform: selectedPlatform, changed: true, initialized: true }
+    }
+    await assertManagedDirectory(selectedPath, selectedPlatform)
+    await rename(selectedPath, activePath)
+    return { platform: selectedPlatform, changed: true, initialized: false }
+  }
+
+  const activePlatform = await readMarker(activePath)
+  if (activePlatform === selectedPlatform) {
+    return { platform: selectedPlatform, changed: false, initialized: false }
+  }
+
+  if (activePlatform === undefined) {
+    if (await inspect(selectedPath) !== undefined) {
+      throw new Error(`${activePath} is unmanaged and ${selectedPath} already exists; move the existing directories before selecting a platform`)
+    }
+    await writeMarker(activePath, selectedPlatform)
+    return { platform: selectedPlatform, changed: true, initialized: false }
+  }
+
+  const previousPath = join(projectRoot, `${ACTIVE_DIRECTORY}.${activePlatform}`)
+  if (await inspect(previousPath) !== undefined) {
+    throw new Error(`${previousPath} already exists; resolve the platform directory before switching`)
+  }
+
+  await rename(activePath, previousPath)
+  try {
+    const selectedInfo = await inspect(selectedPath)
+    if (selectedInfo !== undefined) {
+      await assertManagedDirectory(selectedPath, selectedPlatform)
+      await rename(selectedPath, activePath)
+    } else {
+      await mkdir(activePath, { recursive: true })
+      await writeMarker(activePath, selectedPlatform)
+    }
+  } catch (error) {
+    if (await inspect(activePath) === undefined) await rename(previousPath, activePath).catch(() => undefined)
+    throw error
+  }
+  return { platform: selectedPlatform, changed: true, initialized: false }
+}
+
+const invokedPath = process.argv[1] === undefined ? undefined : resolve(process.argv[1])
+const modulePath = resolve(fileURLToPath(import.meta.url))
+if (invokedPath === modulePath) {
+  try {
+    const result = await selectNodeModules()
+    console.log(result.changed ? `Selected ${result.platform} node_modules.` : `node_modules already selects ${result.platform}.`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -52,6 +52,8 @@ interface FailureEntry {
   until: number
 }
 
+// Keep optional error fields absent rather than explicitly undefined: the
+// typert gateway checks every own enumerable result property for JSON safety.
 const EMPTY_STATE: WhisperModelState = Object.freeze({
   cliAvailable: false,
   downloaded: false,
@@ -59,9 +61,7 @@ const EMPTY_STATE: WhisperModelState = Object.freeze({
   progress: null,
   bytes: null,
   totalBytes: null,
-  error: null,
-  errorCode: undefined,
-  errorParams: undefined
+  error: null
 })
 
 export interface WhisperModelsOptions {
@@ -468,7 +468,12 @@ export class WhisperModels {
     ].join('\n')
     const promise = (async () => {
       const output = await this.runPythonCollect(python, ['-c', script], STATE_COMMAND_TIMEOUT_MS)
-      const parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+      let parsed: { root?: unknown; files?: unknown }
+      try {
+        parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+      } catch {
+        throw new Error('The installed whisper returned an unreadable model table')
+      }
       if (typeof parsed.root !== 'string' || typeof parsed.files !== 'object' || parsed.files === null) {
         throw new Error('Could not read the installed whisper model table')
       }

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -468,21 +468,25 @@ export class WhisperModels {
     ].join('\n')
     const promise = (async () => {
       const output = await this.runPythonCollect(python, ['-c', script], STATE_COMMAND_TIMEOUT_MS)
-      let parsed: { root?: unknown; files?: unknown }
+      let parsed: unknown
       try {
-        parsed = JSON.parse(output.trim()) as { root?: unknown; files?: unknown }
+        parsed = JSON.parse(output.trim())
       } catch {
         throw new Error('The installed whisper returned an unreadable model table')
       }
-      if (typeof parsed.root !== 'string' || typeof parsed.files !== 'object' || parsed.files === null) {
+      if (parsed === null || typeof parsed !== 'object') {
+        throw new Error('The installed whisper returned an unreadable model table')
+      }
+      const { root, files: rawFiles } = parsed as { root?: unknown; files?: unknown }
+      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null) {
         throw new Error('Could not read the installed whisper model table')
       }
       const files = new Map<string, string>()
-      for (const [name, file] of Object.entries(parsed.files as Record<string, unknown>)) {
+      for (const [name, file] of Object.entries(rawFiles as Record<string, unknown>)) {
         if (typeof file === 'string') files.set(name, file)
       }
       if (files.size === 0) throw new Error('The installed whisper exposes no models')
-      return { root: parsed.root, files }
+      return { root, files }
     })()
     this.modelTablePromise = promise
     try {

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -478,7 +478,7 @@ export class WhisperModels {
         throw new Error('The installed whisper returned an unreadable model table')
       }
       const { root, files: rawFiles } = parsed as { root?: unknown; files?: unknown }
-      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null) {
+      if (typeof root !== 'string' || typeof rawFiles !== 'object' || rawFiles === null || Array.isArray(rawFiles)) {
         throw new Error('Could not read the installed whisper model table')
       }
       const files = new Map<string, string>()

--- a/tests/asr-backends.test.ts
+++ b/tests/asr-backends.test.ts
@@ -23,7 +23,9 @@ describe('local Whisper backend', () => {
     await expect(isWhisperAvailable(process.execPath, controller.signal)).resolves.toBe(false)
   })
 
-  it('writes a private temporary audio file and reads the Whisper JSON result', async () => {
+  // These fixtures are POSIX shebang scripts. Native Windows production
+  // installs use a real whisper.exe, so only the fixture-based cases skip.
+  it.skipIf(process.platform === 'win32')('writes a private temporary audio file and reads the Whisper JSON result', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nimport { writeFile } from \'node:fs/promises\'\nimport { join } from \'node:path\'\nconst index = process.argv.indexOf(\'--output_dir\')\nawait writeFile(join(process.argv[index + 1], \'recording.json\'), JSON.stringify({ text: \'本地转录结果\' }))\n')
@@ -42,7 +44,7 @@ describe('local Whisper backend', () => {
     }
   })
 
-  it('carries the whisper stderr tail into transcription failures', async () => {
+  it.skipIf(process.platform === 'win32')('carries the whisper stderr tail into transcription failures', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nprocess.stderr.write(\'Traceback (most recent call last):\\nRuntimeError: model not found\\n\')\nprocess.exit(1)\n')
@@ -61,7 +63,7 @@ describe('local Whisper backend', () => {
     }
   })
 
-  it('preserves the timeout error code when Whisper is aborted by its deadline', async () => {
+  it.skipIf(process.platform === 'win32')('preserves the timeout error code when Whisper is aborted by its deadline', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-ears-test-'))
     const command = join(directory, 'fake-whisper.mjs')
     await writeFile(command, '#!/usr/bin/env node\nsetInterval(() => {}, 1000)\n')

--- a/tests/select-node-modules.test.ts
+++ b/tests/select-node-modules.test.ts
@@ -1,0 +1,54 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { selectNodeModules } from '../scripts/select-node-modules.mjs'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function testRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-ears-node-modules-'))
+  roots.push(root)
+  return root
+}
+
+describe('platform-specific node_modules selection', () => {
+  it('marks an existing install for the current platform', async () => {
+    const root = await testRoot()
+    await mkdir(join(root, 'node_modules'), { recursive: true })
+    await writeFile(join(root, 'node_modules', 'sentinel'), 'windows')
+
+    const result = await selectNodeModules(root, 'win32')
+
+    expect(result).toMatchObject({ platform: 'win32', changed: true })
+    await expect(readFile(join(root, 'node_modules', '.dsh-ears-platform'), 'utf8')).resolves.toBe('win32\n')
+    await expect(readFile(join(root, 'node_modules', 'sentinel'), 'utf8')).resolves.toBe('windows')
+  })
+
+  it('preserves each platform tree while switching the active directory', async () => {
+    const root = await testRoot()
+    await selectNodeModules(root, 'win32')
+    await writeFile(join(root, 'node_modules', 'sentinel'), 'windows')
+
+    await selectNodeModules(root, 'linux')
+    await writeFile(join(root, 'node_modules', 'sentinel'), 'linux')
+    expect(await readFile(join(root, 'node_modules.win32', 'sentinel'), 'utf8')).toBe('windows')
+
+    await selectNodeModules(root, 'win32')
+    await expect(readFile(join(root, 'node_modules', 'sentinel'), 'utf8')).resolves.toBe('windows')
+    await expect(readFile(join(root, 'node_modules.linux', 'sentinel'), 'utf8')).resolves.toBe('linux')
+  })
+
+  it('initializes a platform tree on a fresh checkout', async () => {
+    const root = await testRoot()
+
+    const result = await selectNodeModules(root, 'linux')
+
+    expect(result).toMatchObject({ platform: 'linux', initialized: true })
+    await expect(readFile(join(root, 'node_modules', '.dsh-ears-platform'), 'utf8')).resolves.toBe('linux\n')
+  })
+})

--- a/tests/select-node-modules.test.ts
+++ b/tests/select-node-modules.test.ts
@@ -51,4 +51,18 @@ describe('platform-specific node_modules selection', () => {
     expect(result).toMatchObject({ platform: 'linux', initialized: true })
     await expect(readFile(join(root, 'node_modules', '.dsh-ears-platform'), 'utf8')).resolves.toBe('linux\n')
   })
+
+  it('serializes concurrent conflicting selections', async () => {
+    const root = await testRoot()
+    const selections = Array.from({ length: 12 }, (_, index) =>
+      selectNodeModules(root, index % 2 === 0 ? 'win32' : 'linux'),
+    )
+
+    await expect(Promise.all(selections)).resolves.toHaveLength(selections.length)
+
+    const activePlatform = (await readFile(join(root, 'node_modules', '.dsh-ears-platform'), 'utf8')).trim()
+    expect(['win32', 'linux']).toContain(activePlatform)
+    const preservedPlatform = activePlatform === 'win32' ? 'linux' : 'win32'
+    await expect(readFile(join(root, `node_modules.${preservedPlatform}`, '.dsh-ears-platform'), 'utf8')).resolves.toBe(`${preservedPlatform}\n`)
+  })
 })

--- a/tests/whisper-model-state-wire.test.ts
+++ b/tests/whisper-model-state-wire.test.ts
@@ -1,0 +1,68 @@
+import { dirname } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { WhisperModels, type WhisperModelState } from '../src/asr/whisper-models.js'
+import { whisperModelStateSchema } from '../src/remote-contract.js'
+
+/**
+ * Reproduce the dsh-api-gateway strict result check: the zod parse of a
+ * strict result must keep every own enumerable property JSON-safe. Optional
+ * keys that arrive with an `undefined` value survive the parse as own
+ * properties, so the gateway rejects the business result
+ * ("business result failed boundary validation") even though the schema
+ * accepted it: a WhisperModelState must never carry an `undefined` value.
+ */
+function assertGatewayWireSafe(state: unknown): void {
+  const parsed = whisperModelStateSchema.parse(state)
+  const walk = (value: unknown): void => {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) throw new Error('non-finite number is not JSON-safe')
+      return
+    }
+    if (typeof value !== 'object' || value === null) throw new Error(`${typeof value} is not JSON-safe`)
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      if (item === undefined) throw new Error(`${key} is not JSON-safe`)
+      walk(item)
+    }
+  }
+  walk(parsed)
+}
+
+describe('whisper model state wire safety', () => {
+  it('returns gateway-safe states on every no-interpreter path', async () => {
+    // Keep PATH to the Node directory only: this prevents a real whisper or
+    // Python installation from making the test depend on the host machine.
+    const manager = new WhisperModels({ env: { ...process.env, PATH: dirname(process.execPath) } })
+    try {
+      const states: WhisperModelState[] = [
+        await manager.getWhisperModelState('tiny', false),
+        await manager.getWhisperModelState('tiny', true),
+        await manager.downloadWhisperModel('tiny', false),
+        await manager.downloadWhisperModel('tiny', true),
+        await manager.cancelWhisperModelDownload('tiny', false),
+        await manager.deleteWhisperModel('tiny', true)
+      ]
+      for (const state of states) {
+        expect(state.cliAvailable).toBeTypeOf('boolean')
+        expect(() => assertGatewayWireSafe(state)).not.toThrow()
+      }
+      manager.dispose()
+      const disposed = await manager.getWhisperModelState('tiny', false)
+      expect(() => assertGatewayWireSafe(disposed)).not.toThrow()
+    } finally {
+      manager.dispose()
+    }
+  })
+
+  it('keeps the downloaded-state shape gateway-safe', () => {
+    expect(() => assertGatewayWireSafe({
+      cliAvailable: true,
+      downloaded: true,
+      downloading: false,
+      progress: null,
+      bytes: null,
+      totalBytes: 100,
+      error: null
+    })).not.toThrow()
+  })
+})

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -93,6 +93,7 @@ const FAKE_PYTHON_SCRIPT = [
   "if (script.includes('print(json.dumps')) {",
   "  if (process.env.FAKE_WHISPER_BAD_TABLE === '1') { process.stdout.write('not json\\n'); process.exit(0) }",
   "  if (process.env.FAKE_WHISPER_NULL_TABLE === '1') { process.stdout.write('null\\n'); process.exit(0) }",
+  "  if (process.env.FAKE_WHISPER_ARRAY_TABLE === '1') { process.stdout.write(JSON.stringify({ root: root, files: [] }) + '\\n'); process.exit(0) }",
   "  process.stdout.write(JSON.stringify({ root: root, files: { tiny: 'tiny.pt', base: 'base.pt' } }) + '\\n')",
   '  process.exit(0)',
   '}',
@@ -370,6 +371,19 @@ describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
     try {
       const state = await manager.getWhisperModelState('tiny', true)
       expect(state.error).toContain('unreadable model table')
+      expect(state.errorCode).toBe('whisper.stateQueryFailed')
+    } finally {
+      manager.dispose()
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an array-valued model table files field', async () => {
+    const { cacheDir, env } = await makeEnv({ FAKE_WHISPER_ARRAY_TABLE: '1' })
+    const manager = new WhisperModels({ env })
+    try {
+      const state = await manager.getWhisperModelState('tiny', true)
+      expect(state.error).toContain('Could not read the installed whisper model table')
       expect(state.errorCode).toBe('whisper.stateQueryFailed')
     } finally {
       manager.dispose()

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -121,7 +121,13 @@ const FAKE_PYTHON_SCRIPT = [
   ''
 ].join('\n')
 
-describe('whisper model lifecycle', () => {
+/**
+ * The fake python is a POSIX shebang script; native Windows cannot spawn it
+ * (CreateProcess requires a real PE executable), so the spawn-based lifecycle
+ * suite runs only where the kernel handles the shebang. Platform-independent
+ * coverage remains in the discovery and progress-parsing suites.
+ */
+describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
   let binDir: string
   let baseEnv: NodeJS.ProcessEnv
 

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -92,6 +92,7 @@ const FAKE_PYTHON_SCRIPT = [
   '}',
   "if (script.includes('print(json.dumps')) {",
   "  if (process.env.FAKE_WHISPER_BAD_TABLE === '1') { process.stdout.write('not json\\n'); process.exit(0) }",
+  "  if (process.env.FAKE_WHISPER_NULL_TABLE === '1') { process.stdout.write('null\\n'); process.exit(0) }",
   "  process.stdout.write(JSON.stringify({ root: root, files: { tiny: 'tiny.pt', base: 'base.pt' } }) + '\\n')",
   '  process.exit(0)',
   '}',
@@ -357,6 +358,19 @@ describe.skipIf(process.platform === 'win32')('whisper model lifecycle', () => {
       const second = await manager.getWhisperModelState('tiny', true)
       expect(second.error).toBe(first.error)
       expect(await probeCount()).toBe(afterFirst)
+    } finally {
+      manager.dispose()
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a null model table with a controlled state error', async () => {
+    const { cacheDir, env } = await makeEnv({ FAKE_WHISPER_NULL_TABLE: '1' })
+    const manager = new WhisperModels({ env })
+    try {
+      const state = await manager.getWhisperModelState('tiny', true)
+      expect(state.error).toContain('unreadable model table')
+      expect(state.errorCode).toBe('whisper.stateQueryFailed')
     } finally {
       manager.dispose()
       await rm(cacheDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Cross-platform checkouts now keep native dependency trees and command shims per host platform.

## Changes

- Add `pnpm use:platform`, backed by `scripts/select-node-modules.mjs`.
- Keep the active dependency tree at `node_modules`; preserve Windows and Linux/WSL trees as `node_modules.win32` and `node_modules.linux`.
- Adopt an existing install on first use, preserve it during a platform switch, and create the target tree for the next `pnpm install`.
- Ignore platform-local dependency directories and document the workflow in the Chinese and English README files plus `CONTRIBUTING.md`.
- Add an Ubuntu/Windows CI matrix that selects the platform tree before installing dependencies and runs typecheck/tests.

## Usage

```sh
pnpm use:platform
pnpm install
pnpm check
pnpm test
```

Run `pnpm use:platform` after switching between PowerShell and WSL, then install dependencies for the selected host. Stop active development servers before switching trees.

## Verification

- `tsc --noEmit`: passed.
- Linux worktree: 28 test files and 286 tests passed.
- Selector tests cover fresh initialization, adoption of an existing install, and round-trip switching between Windows and Linux trees.
- GitHub Actions validates both `ubuntu-latest` and `windows-latest` on pushes to `master` and pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added platform switching for Windows and Linux/WSL dependency installations.
  - Added safeguards to preserve separate platform-specific dependencies and recover from failed switches.
  - Added a setup command for selecting the active platform.

- **Documentation**
  - Updated installation and contribution guides with platform selection instructions.

- **Tests**
  - Added coverage for platform switching, preservation, and fresh setup scenarios.

- **Chores**
  - Added continuous integration checks across Ubuntu and Windows.
  - Improved dependency-directory exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->