### PR TITLE
fix(ci): allow native Whisper install scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  '@fugood/whisper.node': true
+
 minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.8 || 0.1.1-rc.2'
   - '@deepseek-ai/dsh-agent-presets@0.1.0-rc.8 || 0.1.1-rc.2'


### PR DESCRIPTION
## Summary
- allow the `@fugood/whisper.node` native package postinstall script in pnpm 11
- restore dependency installation in the Ubuntu and Windows CI jobs

## Validation
- `pnpm use:platform`
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the required build process for the speech recognition component, improving installation and setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->