### PR TITLE
fix(client): abort superseded media captures on rapid mic toggles

### DIFF
--- a/src/client/MicrophoneButton.tsx
+++ b/src/client/MicrophoneButton.tsx
@@ -14,7 +14,7 @@ import { base64ByteLength, classifyVoiceFailure, failureMessage, isTrivialRecord
 import { commitTranscript, updateDraft } from './voice-flow.js'
 import { matchesShortcut } from '../shortcut.js'
 import { fallbackTranslate, localizedErrorText, type Translate } from './settings-locale.js'
-import { resolveCaptureBackend, shouldAbandonPendingCapture, webSpeechCommittedTranscript } from './voice-capture.js'
+import { resolveCaptureBackend, isSupersededMediaCapture, shouldAbandonPendingCapture, webSpeechCommittedTranscript } from './voice-capture.js'
 import { micUnavailableReason, type MicUnavailableReason } from './mic-availability.js'
 import type { BackendHook, WhisperModelHook } from './settings-controller.js'
 import { playClick, resumeSounds, retainSounds } from './sounds.js'
@@ -49,6 +49,7 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
   const mediaBaseDraftRef = useRef('')
   const mediaStartedAtRef = useRef(0)
   const mediaStartCancelledRef = useRef(false)
+  const mediaStartGenerationRef = useRef(0)
   const mediaBackendRef = useRef<MediaCaptureBackend | null>(null)
   const transcribeAbortRef = useRef<AbortController | null>(null)
   const polishAbortRef = useRef<AbortController | null>(null)
@@ -374,12 +375,13 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
 
   const startMediaRecording = async (backend: MediaCaptureBackend) => {
     const baseDraft = input.draft
+    const generation = ++mediaStartGenerationRef.current
     mediaStartCancelledRef.current = false
     setState('starting')
     let session: MediaRecorderSession | undefined
     try {
       session = await MediaRecorderSession.create()
-      if (shouldAbandonPendingCapture(mountedRef.current, mediaStartCancelledRef.current)) {
+      if (isSupersededMediaCapture(mediaStartGenerationRef.current, generation) || shouldAbandonPendingCapture(mountedRef.current, mediaStartCancelledRef.current)) {
         session.abort()
         return
       }
@@ -396,17 +398,18 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
         // Recording remains usable when the optional waveform analyser is unavailable.
       }
     } catch {
-      levelMonitorRef.current?.stop()
-      levelMonitorRef.current = null
       session?.abort()
       if (mediaSessionRef.current === session) {
         mediaSessionRef.current = null
         mediaBackendRef.current = null
       }
-      if (mountedRef.current) {
-        if (mediaStartCancelledRef.current) setState('idle')
-        else applyVoiceFailure(voiceSession, 'asr', new Error('Media recording is unavailable in this browser'))
-      }
+      // A superseded start owns neither the shared refs nor the UI state; the
+      // newer initiation reports its own outcome.
+      if (!mountedRef.current || isSupersededMediaCapture(mediaStartGenerationRef.current, generation)) return
+      levelMonitorRef.current?.stop()
+      levelMonitorRef.current = null
+      if (mediaStartCancelledRef.current) setState('idle')
+      else applyVoiceFailure(voiceSession, 'asr', new Error('Media recording is unavailable in this browser'))
     }
   }
 

--- a/src/client/MicrophoneButton.tsx
+++ b/src/client/MicrophoneButton.tsx
@@ -200,6 +200,10 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
 
   const startWebSpeech = () => {
     let baseDraft = input.draft
+    // Starting Web Speech supersedes any still-pending media capture; claim a
+    // new generation before resetting the shared cancel flag so the pending
+    // MediaRecorderSession.create() cannot pass its staleness check later.
+    mediaStartGenerationRef.current += 1
     let sessionDraft = baseDraft
     let failed = false
     mediaStartCancelledRef.current = false

--- a/src/client/voice-capture.ts
+++ b/src/client/voice-capture.ts
@@ -45,6 +45,16 @@ export function shouldAbandonPendingCapture(mounted: boolean, cancelled: boolean
 }
 
 /**
+ * Every media-capture initiation claims the next generation number. A newer
+ * start resets the shared cancel flag, so a still-pending create() that
+ * resolves afterwards would pass the flag check and steal the live session
+ * slot; a capture whose generation is no longer current must abort instead.
+ */
+export function isSupersededMediaCapture(latestGeneration: number, generation: number): boolean {
+  return latestGeneration !== generation
+}
+
+/**
  * Prefer the recognition session's own text. When the browser emits no final
  * result, recover the live draft slice written by interim updates.
  */

--- a/tests/voice-capture.test.ts
+++ b/tests/voice-capture.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   decideMicrophoneClick,
+  isSupersededMediaCapture,
   resolveCaptureBackend,
   shouldAbandonPendingCapture,
   voiceToggleAction,
@@ -80,6 +81,18 @@ describe('shouldAbandonPendingCapture', () => {
     expect(shouldAbandonPendingCapture(false, false)).toBe(true)
     expect(shouldAbandonPendingCapture(true, true)).toBe(true)
     expect(shouldAbandonPendingCapture(false, true)).toBe(true)
+  })
+})
+
+describe('isSupersededMediaCapture', () => {
+  it('aborts a pending create that resolves after a newer initiation reset the cancel flag', () => {
+    // start (generation 1) -> cancel -> start again (generation 2): the first
+    // create() must not pass the cancelled-flag check and steal the session.
+    expect(isSupersededMediaCapture(2, 1)).toBe(true)
+  })
+
+  it('keeps a capture whose generation is still the latest initiation', () => {
+    expect(isSupersededMediaCapture(1, 1)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Problem

Rapid microphone toggles (click/shortcut: start → cancel → start again before `MediaRecorderSession.create()` resolves) could orphan a live `MediaRecorderSession`. The shared `mediaStartCancelledRef` flag is reset by every new start, so the first pending `create()` passed the abandonment check, wrote itself into `mediaSessionRef.current`, and was then overwritten by the second session — leaving an audio track open with no way to stop it from the UI until page reload.

## Fix

Each media-capture initiation now claims the next value of `mediaStartGenerationRef`. After `create()` resolves, the session is only retained when its generation is still current; otherwise it aborts immediately. Late `create()` failures from a superseded initiation also stop touching shared refs or the voice UI state — the newest initiation owns both.

`isSupersededMediaCapture` lives in `voice-capture.ts` next to the existing `shouldAbandonPendingCapture` helper so the race decision stays unit-testable.

Fixes #9

## Test plan

- `pnpm check`, `pnpm test` (336 passed)
- New cases in `tests/voice-capture.test.ts` cover superseded and current generations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone recording reliability when capture requests are cancelled, superseded, or interrupted.
  * Prevented outdated recording attempts from overwriting the current recording state or displaying incorrect failure messages.
  * Ensured only the latest active recording request controls microphone status and results.

* **Tests**
  * Added coverage for handling superseded and current microphone capture requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->