### PR TITLE
fix(client): join CJK speech segments without half-width spaces

### DIFF
--- a/src/asr/web-speech.ts
+++ b/src/asr/web-speech.ts
@@ -1,3 +1,5 @@
+import { joinSpacedSegments } from '../text-join.js'
+
 export type WebSpeechState = 'starting' | 'recording' | 'stopped' | 'error'
 
 type SpeechRecognitionAlternativeLike = {
@@ -197,10 +199,7 @@ export class WebSpeechSession {
 }
 
 export function appendSpeech(current: string, next: string): string {
-  if (next === '') return current
-  if (current === '') return next
-  if (/\s$/.test(current) || /^\s/.test(next)) return current + next
-  return `${current} ${next}`
+  return joinSpacedSegments(current, next)
 }
 
 function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | undefined {

--- a/src/client/voice-flow.ts
+++ b/src/client/voice-flow.ts
@@ -1,5 +1,6 @@
 import type { EarsSettings } from '../config.js'
 import { isEarsErrorCode } from '../errors.js'
+import { joinSpacedSegments } from '../text-join.js'
 import type { EarsRemote } from '../remote.js'
 import { classifyVoiceFailure, failureMessage, remoteFailureDetail, remoteFailureParams } from './voice-error.js'
 import type { VoiceStateDetailParams } from './voice-session.js'
@@ -173,8 +174,5 @@ export function updateDraft(
 }
 
 export function appendToDraft(baseDraft: string, transcript: string): string {
-  if (transcript === '') return baseDraft
-  if (baseDraft === '') return transcript
-  if (/\s$/.test(baseDraft) || /^\s/.test(transcript)) return baseDraft + transcript
-  return `${baseDraft} ${transcript}`
+  return joinSpacedSegments(baseDraft, transcript)
 }

--- a/src/text-join.ts
+++ b/src/text-join.ts
@@ -1,11 +1,15 @@
 /**
- * CJK scripts and full-width punctuation carry no inter-word spaces, so two
- * segments meeting on such a character join directly. Everything else keeps
- * the half-width space that Latin text relies on; mixed-script boundaries
- * also keep the space for readability.
+ * CJK scripts carry no inter-word spaces, and full-width punctuation is
+ * already self-delimiting, so segments meeting on such characters join
+ * directly. Everything else keeps the half-width space that Latin text
+ * relies on; mixed-script boundaries also keep the space for readability.
  */
-const CJK_BOUNDARY_HEAD = /^(?:\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|[\u3000-\u303f\u30fc\uff01-\uff20\uff3b-\uff40\uff5b-\uff65\u2014\u2026])/u
-const CJK_BOUNDARY_TAIL = /(?:\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|[\u3000-\u303f\u30fc\uff01-\uff20\uff3b-\uff40\uff5b-\uff65\u2014\u2026])$/u
+const CJK_SCRIPT = '\\p{Script=Han}|\\p{Script=Hiragana}|\\p{Script=Katakana}|\\p{Script=Hangul}'
+const FULL_WIDTH_PUNCTUATION = '[\\u3000-\u303f\\u30fc\\uff01-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65\\u2014\\u2026]'
+const FULL_WIDTH_PUNCTUATION_HEAD = new RegExp(`^${FULL_WIDTH_PUNCTUATION}`, 'u')
+const FULL_WIDTH_PUNCTUATION_TAIL = new RegExp(`${FULL_WIDTH_PUNCTUATION}$`, 'u')
+const CJK_SCRIPT_HEAD = new RegExp(`^(?:${CJK_SCRIPT})`, 'u')
+const CJK_SCRIPT_TAIL = new RegExp(`(?:${CJK_SCRIPT})$`, 'u')
 
 /**
  * Join two streamed speech segments or draft appends, inserting a separator
@@ -15,6 +19,9 @@ export function joinSpacedSegments(current: string, next: string): string {
   if (next === '') return current
   if (current === '') return next
   if (/\s$/.test(current) || /^\s/.test(next)) return current + next
-  if (CJK_BOUNDARY_TAIL.test(current) && CJK_BOUNDARY_HEAD.test(next)) return current + next
+  // Full-width punctuation delimits on its own, so either side joins without
+  // a space; a plain CJK-to-CJK script boundary does too.
+  if (FULL_WIDTH_PUNCTUATION_TAIL.test(current) || FULL_WIDTH_PUNCTUATION_HEAD.test(next)) return current + next
+  if (CJK_SCRIPT_TAIL.test(current) && CJK_SCRIPT_HEAD.test(next)) return current + next
   return `${current} ${next}`
 }

--- a/src/text-join.ts
+++ b/src/text-join.ts
@@ -5,7 +5,9 @@
  * relies on; mixed-script boundaries also keep the space for readability.
  */
 const CJK_SCRIPT = '\\p{Script=Han}|\\p{Script=Hiragana}|\\p{Script=Katakana}|\\p{Script=Hangul}'
-const FULL_WIDTH_PUNCTUATION = '[\\u3000-\u303f\\u30fc\\uff01-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65\\u2014\\u2026]'
+// Full-width punctuation only; full-width digits (０-９) are content
+// characters, not delimiters.
+const FULL_WIDTH_PUNCTUATION = '[\\u3000-\\u303f\\u30fc\\uff01-\\uff0f\\uff1a-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65\\u2014\\u2026]'
 const FULL_WIDTH_PUNCTUATION_HEAD = new RegExp(`^${FULL_WIDTH_PUNCTUATION}`, 'u')
 const FULL_WIDTH_PUNCTUATION_TAIL = new RegExp(`${FULL_WIDTH_PUNCTUATION}$`, 'u')
 const CJK_SCRIPT_HEAD = new RegExp(`^(?:${CJK_SCRIPT})`, 'u')

--- a/src/text-join.ts
+++ b/src/text-join.ts
@@ -1,0 +1,20 @@
+/**
+ * CJK scripts and full-width punctuation carry no inter-word spaces, so two
+ * segments meeting on such a character join directly. Everything else keeps
+ * the half-width space that Latin text relies on; mixed-script boundaries
+ * also keep the space for readability.
+ */
+const CJK_BOUNDARY_HEAD = /^(?:\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|[\u3000-\u303f\u30fc\uff01-\uff20\uff3b-\uff40\uff5b-\uff65\u2014\u2026])/u
+const CJK_BOUNDARY_TAIL = /(?:\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|[\u3000-\u303f\u30fc\uff01-\uff20\uff3b-\uff40\uff5b-\uff65\u2014\u2026])$/u
+
+/**
+ * Join two streamed speech segments or draft appends, inserting a separator
+ * space only where the writing system expects one.
+ */
+export function joinSpacedSegments(current: string, next: string): string {
+  if (next === '') return current
+  if (current === '') return next
+  if (/\s$/.test(current) || /^\s/.test(next)) return current + next
+  if (CJK_BOUNDARY_TAIL.test(current) && CJK_BOUNDARY_HEAD.test(next)) return current + next
+  return `${current} ${next}`
+}

--- a/tests/text-join.test.ts
+++ b/tests/text-join.test.ts
@@ -33,4 +33,9 @@ describe('joinSpacedSegments', () => {
     expect(joinSpacedSegments('你好', 'world')).toBe('你好 world')
     expect(joinSpacedSegments('价格100', '元')).toBe('价格100 元')
   })
+
+  it('joins directly when either boundary is full-width punctuation', () => {
+    expect(joinSpacedSegments('结束了。', 'next')).toBe('结束了。next')
+    expect(joinSpacedSegments('hello', '「引文」')).toBe('hello「引文」')
+  })
 })

--- a/tests/text-join.test.ts
+++ b/tests/text-join.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { joinSpacedSegments } from '../src/text-join.js'
+
+describe('joinSpacedSegments', () => {
+  it('keeps empty-side semantics', () => {
+    expect(joinSpacedSegments('', 'hello')).toBe('hello')
+    expect(joinSpacedSegments('hello', '')).toBe('hello')
+    expect(joinSpacedSegments('', '')).toBe('')
+  })
+
+  it('separates Latin segments with a space', () => {
+    expect(joinSpacedSegments('hello', 'world')).toBe('hello world')
+    expect(joinSpacedSegments('hello', ' world')).toBe('hello world')
+    expect(joinSpacedSegments('hello ', 'world')).toBe('hello world')
+  })
+
+  it('joins CJK segments without a space', () => {
+    expect(joinSpacedSegments('今天天气', '很好')).toBe('今天天气很好')
+    expect(joinSpacedSegments('你好', '世界')).toBe('你好世界')
+    expect(joinSpacedSegments('こんにちは', '世界')).toBe('こんにちは世界')
+    expect(joinSpacedSegments('안녕', '하세요')).toBe('안녕하세요')
+  })
+
+  it('joins across full-width punctuation without a space', () => {
+    expect(joinSpacedSegments('你好，', '世界')).toBe('你好，世界')
+    expect(joinSpacedSegments('结束了。', '明天见')).toBe('结束了。明天见')
+    expect(joinSpacedSegments('第一点……', '第二点')).toBe('第一点……第二点')
+    expect(joinSpacedSegments('「引文」', '正文')).toBe('「引文」正文')
+  })
+
+  it('keeps the space on mixed-script boundaries for readability', () => {
+    expect(joinSpacedSegments('hello', '你好')).toBe('hello 你好')
+    expect(joinSpacedSegments('你好', 'world')).toBe('你好 world')
+    expect(joinSpacedSegments('价格100', '元')).toBe('价格100 元')
+  })
+})

--- a/tests/text-join.test.ts
+++ b/tests/text-join.test.ts
@@ -38,4 +38,8 @@ describe('joinSpacedSegments', () => {
     expect(joinSpacedSegments('结束了。', 'next')).toBe('结束了。next')
     expect(joinSpacedSegments('hello', '「引文」')).toBe('hello「引文」')
   })
+
+  it('keeps the space around full-width digits, which are content characters', () => {
+    expect(joinSpacedSegments('编号１２３', '456')).toBe('编号１２３ 456')
+  })
 })

--- a/tests/voice-flow.test.ts
+++ b/tests/voice-flow.test.ts
@@ -401,6 +401,11 @@ describe('voice draft flow', () => {
     expect(appendToDraft('hello', ' world')).toBe('hello world')
   })
 
+  it('appends CJK transcripts without an interposed space', () => {
+    expect(appendToDraft('你好', '世界')).toBe('你好世界')
+    expect(appendToDraft('写完了。', '睡觉')).toBe('写完了。睡觉')
+  })
+
   it('returns the draft written by a live recognition update', () => {
     const setDraft = vi.fn()
     const latestDraftRef = { current: 'original draft' }

--- a/tests/web-speech.test.ts
+++ b/tests/web-speech.test.ts
@@ -44,6 +44,11 @@ describe('appendSpeech', () => {
     expect(appendSpeech('hello', ' world')).toBe('hello world')
     expect(appendSpeech('hello', 'world')).toBe('hello world')
   })
+
+  it('joins CJK results without an interposed space', () => {
+    expect(appendSpeech('今天天气', '很好')).toBe('今天天气很好')
+    expect(appendSpeech('结束了。', '明天见')).toBe('结束了。明天见')
+  })
 })
 
 describe('WebSpeechSession', () => {


### PR DESCRIPTION
## Problem

`appendSpeech` (`src/asr/web-speech.ts`) and `appendToDraft` (`src/client/voice-flow.ts`) inserted a half-width space on every join. For Chinese/Japanese dictation this corrupts the text: streamed results like "今天天气" + "很好" became "今天天气 很好", and appending to an existing draft produced "你好 世界". Full-width punctuation did not suppress the space either ("……，  下一句").

## Fix

New shared helper `joinSpacedSegments` in `src/text-join.ts`: a separator space is inserted only when at least one boundary character is not CJK script (Han/Hiragana/Katakana/Hangul) or full-width CJK punctuation. Latin–Latin and mixed-script boundaries keep today's readable space; existing whitespace-boundary behavior is unchanged.

Both public functions delegate to the helper, so their exported names and call sites stay untouched.

Fixes #11

## Test plan

- `pnpm check`, `pnpm test` (341 passed)
- New `tests/text-join.test.ts` covers empty sides, Latin, CJK, full-width punctuation boundaries, and mixed-script spacing
- CJK regression cases added to `tests/web-speech.test.ts` and `tests/voice-flow.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed speech and voice transcript formatting.
  - Prevented unwanted spaces between Chinese, Japanese, Korean, and full-width punctuation.
  - Preserved appropriate spacing between Latin and mixed-script text.
  - Preserved existing whitespace while handling empty transcript segments consistently.

- **Tests**
  - Added coverage for empty inputs, Latin spacing, CJK concatenation, punctuation, and mixed-script boundaries.
  - Verified consistent formatting across voice drafts and speech recognition transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->