### PR TITLE
fix(whisper): report download failures once, then probe the filesystem again

### DIFF
--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -233,8 +233,7 @@ export class WhisperModels {
         )
       }
       this.verifiedFiles.delete(filePath)
-      await rm(marker, { force: true }).catch(() => undefined)
-      await rm(`${filePath}${DOWNLOAD_PARTIAL_SUFFIX}`, { force: true }).catch(() => undefined)
+      this.sweepMissingModelArtifacts(filePath, marker, model)
       return {
         runtimeAvailable,
         downloaded: false,
@@ -343,6 +342,39 @@ export class WhisperModels {
     this.downloadSetup = new Promise((resolve) => { release = resolve })
     await previous
     return release
+  }
+
+  /**
+   * Opportunistically clear the leftover marker and partial file once the
+   * model file is gone. The sweep never blocks the state query: it queues on
+   * the download-setup lock, so a retry download that starts meanwhile either
+   * wins the lock first (the re-check below sees its live handle and skips)
+   * or runs after the sweep finished — it can never lose its partial file to
+   * this cleanup mid-write.
+   */
+  private sweepMissingModelArtifacts(filePath: string, markerPath: string, model: WhisperModelId): void {
+    void this.acquireDownloadSetup()
+      .then(async (release) => {
+        try {
+          const handle = this.activeDownload
+          if (handle !== undefined && !handle.finished && handle.model === model) return
+          try {
+            await stat(filePath)
+            // A model file reappeared (placed or restored); leave the artifacts
+            // to the verification path instead of deleting its marker.
+            return
+          } catch {
+            // Still missing; sweeping is safe.
+          }
+          await Promise.all([
+            rm(markerPath, { force: true }),
+            rm(`${filePath}${DOWNLOAD_PARTIAL_SUFFIX}`, { force: true })
+          ])
+        } finally {
+          release()
+        }
+      })
+      .catch(() => undefined)
   }
 
   private modelPath(model: WhisperModelId, definition: WhisperModelDefinition): string {

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -363,8 +363,10 @@ export class WhisperModels {
             // A model file reappeared (placed or restored); leave the artifacts
             // to the verification path instead of deleting its marker.
             return
-          } catch {
-            // Still missing; sweeping is safe.
+          } catch (error) {
+            // Only sweep on a confirmed missing file; any other stat failure
+            // may be transient and must not destroy a valid marker.
+            if (!isMissingFile(error)) return
           }
           await Promise.all([
             rm(markerPath, { force: true }),

--- a/src/asr/whisper-models.ts
+++ b/src/asr/whisper-models.ts
@@ -179,7 +179,14 @@ export class WhisperModels {
 
     const handle = this.activeDownload
     if (handle !== undefined && handle.model === model) {
-      if (!handle.finished || handle.error !== null) return stateFromHandle(handle, runtimeAvailable)
+      if (!handle.finished) return stateFromHandle(handle, runtimeAvailable)
+      // Report a terminal download failure exactly once, then drop the
+      // handle so later queries probe the filesystem again instead of
+      // repeating the stale in-memory failure until a host restart.
+      if (handle.error !== null) {
+        this.activeDownload = undefined
+        return stateFromHandle(handle, runtimeAvailable)
+      }
     }
 
     const definition = this.manifest[model]

--- a/tests/whisper-models.test.ts
+++ b/tests/whisper-models.test.ts
@@ -177,6 +177,30 @@ describe('whisper.cpp model lifecycle', () => {
     streamController?.error(new Error('closed'))
   })
 
+  it('falls back to filesystem probing after reporting a failed download once', async () => {
+    const { manager, cacheDir } = await makeManager(async () => {
+      throw new Error('network unreachable')
+    })
+    await manager.downloadWhisperModel('tiny', true)
+    const failed = await waitForState(manager, (state) => !state.downloading)
+    expect(failed.error).toBe('network unreachable')
+    expect(failed.downloaded).toBe(false)
+
+    await expect(manager.getWhisperModelState('tiny', true)).resolves.toMatchObject({
+      downloaded: false,
+      downloading: false,
+      error: null
+    })
+
+    // A manually recovered and verified model becomes visible without a restart.
+    await writeFile(`${cacheDir}/ggml-tiny.bin`, TEST_BYTES)
+    await writeFile(`${cacheDir}/ggml-tiny.bin.dsh-ears-done`, JSON.stringify({ version: 1, model: 'tiny', sha256: TEST_SHA256, bytes: TEST_BYTES.byteLength }))
+    await expect(manager.getWhisperModelState('tiny', true)).resolves.toMatchObject({
+      downloaded: true,
+      error: null
+    })
+  })
+
   it('deletes the model, marker, and stale partial file', async () => {
     const { manager, cacheDir } = await makeManager()
     await manager.downloadWhisperModel('tiny', true)


### PR DESCRIPTION
## Problem

After a failed model download, `WhisperModels.activeDownload` kept the finished handle forever. `getWhisperModelState` short-circuits whenever `handle.error !== null` (`src/asr/whisper-models.ts`), so every later query repeated the stale in-memory failure and skipped the disk `stat` + SHA-256 verification — even if the verified model file was placed back into the cache directory. Recovery required clicking download again or restarting the host, and the settings UI kept showing the old error across reopenings.

## Fix

A terminal failure is now **reported exactly once**: the first query that observes the finished-and-failed handle returns its error state (preserving the surfaced failure for the polling client) and then clears `activeDownload`. All subsequent queries fall through to filesystem probing, so recovery is visible without a restart. Successful downloads already fell through (`finished && error === null`) and are unaffected; in-flight downloads still return live progress.

Fixes #8

## Test plan

- `pnpm check`, `pnpm test` (335 passed)
- New regression test: failed download reports its error once → next query shows a clean not-downloaded state → manually placing the verified file + marker yields `downloaded: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Download status now updates immediately while a model download is in progress.
  - Failed downloads report errors once and clear stale failure states on subsequent checks.
  - Restored or previously completed models are detected correctly after a failed download.

- **Tests**
  - Added coverage for download failure recovery and subsequent model detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->