### PR TITLE
fix(polish): keep chronological 第X narratives out of the numbered-list layout

### DIFF
--- a/src/polish/enumeration.ts
+++ b/src/polish/enumeration.ts
@@ -1,5 +1,8 @@
 const CHINESE_ORDINAL = /第[一二三四五六七八九十]/g
-const FALSE_ORDINAL_TAIL = /^(名|时间|反应|印象|人称)/
+// Ordinals that head time, quantity, or measure phrases (第一天, 第二批,
+// 第一步) narrate a sequence instead of enumerating list items; splitting on
+// them corrupted the sentence and dropped the classifier into the first item.
+const FALSE_ORDINAL_TAIL = /^(名|时间|反应|印象|人称|天|日|夜|周|月|年|季度|批|轮|次|个|步|阶段)/
 const ORDINAL_TAIL = /^(点|是)?[，,、.\s]*/
 const INLINE_ARABIC_ITEM = /(?<=\S)\s+(?=[2-9]\.\s|[1-9]\d\.\s)/g
 

--- a/tests/enumeration.test.ts
+++ b/tests/enumeration.test.ts
@@ -36,6 +36,18 @@ describe('applySpokenEnumerationLayout', () => {
     expect(applySpokenEnumerationLayout('第一时间把 Security Key 发我')).toBe('第一时间把 Security Key 发我')
   })
 
+  it('keeps chronological narratives as prose instead of corrupting them into lists', () => {
+    const narratives = [
+      '第一天去了海边，第二天去爬山',
+      '第一批货物已经发出，第二批下周到',
+      '第一步需要先注册，第二步登录',
+      '第一年打基础，第二年见成效'
+    ]
+    for (const narrative of narratives) {
+      expect(applySpokenEnumerationLayout(narrative)).toBe(narrative)
+    }
+  })
+
   it('leaves an already multiline numbered list alone', () => {
     const listed = '1. 预算\n2. 接口文档'
     expect(applySpokenEnumerationLayout(listed)).toBe(listed)


### PR DESCRIPTION
## Problem

`layoutChineseOrdinals` treated every `第[一-十]` pair as an enumeration. Chronological/sequential narratives were corrupted into broken lists:

| Spoken text | Before |
| --- | --- |
| 第一天去了海边，第二天去爬山 | `1. 天去了海边，` / `2. 天去爬山` |
| 第一批货物已经发出，第二批下周到 | same corruption |
| 第一步需要先注册，第二步登录 | `1. 步需要先注册，` / `2. 步登录` |

Note the items keep the classifier (天/批/步) because the layout slices after the ordinal marker — this form was never producing useful lists.

## Fix

Extend `FALSE_ORDINAL_TAIL` with time and measure classifiers: 天 日 夜 周 月 年 季度 批 轮 次 个 步 阶段 (joining the existing 名 时间 反应 印象 人称). These sentences now stay prose. Bare glued ordinals (`第一帮我看一下……第二……`) and punctuated pairs (`第一，……第二，……`) still format as numbered lists; all pre-existing test cases pass unchanged.

The issue also suggested requiring punctuation after each ordinal, but that would break the intended glued-prose case covered by `tests/enumeration.test.ts`, so classifier exclusion is used instead.

Fixes #12

## Test plan

- `pnpm check`, `pnpm test` (335 passed)
- New case asserts all four narrative examples from the issue remain untouched prose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Chinese ordinal phrases in chronological, quantitative, measurement, and sequence contexts.
  * Prevented narrative text using phrases such as “第一” and “第二” from being incorrectly converted into numbered lists.

* **Tests**
  * Added regression coverage for Chinese narratives containing ordinal phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->