### PR TITLE
fix(package): harden dsh-market compatibility

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/dsh-0.1.0--rc.6%20--%200.1.1--rc.2-1a73e8?style=flat-square" alt="dsh 0.1.0-rc.6 - 0.1.1-rc.2"></a>
+  <a href="https://www.npmjs.com/package/dsh-ears"><img src="https://img.shields.io/npm/v/dsh-ears?style=flat-square&logo=npm" alt="npm version"></a>
   <img src="https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node.js">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT"></a>
 </p>
@@ -84,6 +85,12 @@ npx -y @deepseek-ai/dsh plugin --profile web remove dsh-ears
 ```
 
 The command removes the dsh plugin registration and leaves a local clone in place. Refresh the Web UI afterwards; the microphone icon disappears.
+
+## DSH Plugin Market
+
+`dsh-ears` is listed in the DSH Plugin Market, where it can be installed, updated, and uninstalled from Settings → Plugin Market. The market installs the published npm package and can usually hot-load a fresh installation.
+
+When an update includes Host code, the market reports that dsh must be restarted; the new version is fully active after the restart. Uninstalling removes the plugin and its runtime registration but keeps dsh-ears settings, cloud API keys, and downloaded Whisper models so a later reinstall can reuse them.
 
 ## Usage
 

--- a/README.en.md
+++ b/README.en.md
@@ -88,9 +88,7 @@ The command removes the dsh plugin registration and leaves a local clone in plac
 
 ## DSH Plugin Market
 
-`dsh-ears` is listed in the DSH Plugin Market, where it can be installed, updated, and uninstalled from Settings → Plugin Market. The market installs the published npm package and can usually hot-load a fresh installation.
-
-When an update includes Host code, the market reports that dsh must be restarted; the new version is fully active after the restart. Uninstalling removes the plugin and its runtime registration but keeps dsh-ears settings, cloud API keys, and downloaded Whisper models so a later reinstall can reuse them.
+`dsh-ears` is listed in [DSH Market](https://github.com/dsh-market/dsh-market), where it can be installed, updated, and uninstalled directly from Settings → Plugin Market.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,7 @@ npx -y @deepseek-ai/dsh plugin --profile web remove dsh-ears
 
 ## DSH 插件市场
 
-`dsh-ears` 已收录到 DSH 插件市场，可在设置 → 插件市场中直接安装、更新和卸载。市场安装使用 npm 发布包，安装完成后通常可以热加载。
-
-更新包含 Host 代码时，市场会提示重启 dsh，重启后新版本才会完全生效。卸载会移除插件和运行时注册，但会保留 dsh-ears 的设置、云端 API key 和已下载的 Whisper 模型，重新安装后可以继续使用。
+`dsh-ears` 已被 [DSH Market](https://github.com/dsh-market/dsh-market) 收录，可在设置 → 插件市场中直接安装、更新和卸载。
 
 ## 使用
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/dsh-0.1.0--rc.6%20--%200.1.1--rc.2-1a73e8?style=flat-square" alt="dsh 0.1.0-rc.6 - 0.1.1-rc.2"></a>
+  <a href="https://www.npmjs.com/package/dsh-ears"><img src="https://img.shields.io/npm/v/dsh-ears?style=flat-square&logo=npm" alt="npm version"></a>
   <img src="https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node.js">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT"></a>
 </p>
@@ -84,6 +85,12 @@ npx -y @deepseek-ai/dsh plugin --profile web remove dsh-ears
 ```
 
 这条命令会移除 dsh 中的插件注册，源码目录保持不变。卸载后刷新 Web UI，麦克风图标会消失。
+
+## DSH 插件市场
+
+`dsh-ears` 已收录到 DSH 插件市场，可在设置 → 插件市场中直接安装、更新和卸载。市场安装使用 npm 发布包，安装完成后通常可以热加载。
+
+更新包含 Host 代码时，市场会提示重启 dsh，重启后新版本才会完全生效。卸载会移除插件和运行时注册，但会保留 dsh-ears 的设置、云端 API key 和已下载的 Whisper 模型，重新安装后可以继续使用。
 
 ## 使用
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "git+https://github.com/WizisCool/dsh-ears.git"
   },
   "type": "module",
+  "engines": {
+    "node": "^22.19.0 || >=24.0.0"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "exports": {
@@ -79,7 +82,8 @@
     "dev:watch": "tsdown --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepack": "pnpm build",
+    "verify:package": "node scripts/verify-package.mjs",
+    "prepack": "pnpm build && pnpm verify:package",
     "prepare:patch": "node scripts/create-dev-patch.mjs",
     "dev:config": "pnpm build && pnpm prepare:patch && dsh --profile web --dump-config --patch ./.dsh/cordis.patch.yml",
     "dev:web": "pnpm build && pnpm prepare:patch && dsh --profile web --patch ./.dsh/cordis.patch.yml"

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packagePath = join(root, 'package.json')
+const manifest = JSON.parse(readFileSync(packagePath, 'utf8'))
+const failures = []
+
+function fail(message) {
+  failures.push(message)
+}
+
+function requireFile(label, relativePath) {
+  if (typeof relativePath !== 'string' || relativePath === '') {
+    fail(`${label} must name a file`)
+    return
+  }
+  const path = relativePath.replace(/^\.\//u, '')
+  if (!existsSync(join(root, path))) fail(`${label} is missing: ${relativePath}`)
+}
+
+function requireExport(target, condition) {
+  const entry = manifest.exports?.[target]
+  const value = entry !== null && typeof entry === 'object' && !Array.isArray(entry)
+    ? entry[condition]
+    : undefined
+  requireFile(`exports[${JSON.stringify(target)}].${condition}`, value)
+}
+
+if (typeof manifest.name !== 'string' || manifest.name === '') fail('package name is missing')
+if (typeof manifest.version !== 'string' || manifest.version === '') fail('package version is missing')
+if (manifest.engines?.node !== '^22.19.0 || >=24.0.0') {
+  fail('engines.node must match the supported Node range')
+}
+
+requireFile('main', manifest.main)
+requireFile('types', manifest.types)
+requireExport('.', 'default')
+requireExport('.', 'types')
+requireExport('./client', 'default')
+requireExport('./client', 'types')
+requireExport('./typert', 'default')
+requireExport('./typert', 'types')
+requireExport('./remote', 'default')
+requireExport('./remote', 'types')
+
+if (!Array.isArray(manifest.files) || !manifest.files.includes('lib')) {
+  fail('files must include lib')
+}
+if (!Array.isArray(manifest.files) || !manifest.files.includes('cordis.patch.yml')) {
+  fail('files must include cordis.patch.yml')
+}
+
+const patchPath = manifest.dsh?.bundle?.patch
+if (patchPath !== './cordis.patch.yml') {
+  fail('dsh.bundle.patch must point to ./cordis.patch.yml')
+} else {
+  requireFile('dsh.bundle.patch', patchPath)
+  const patch = readFileSync(join(root, patchPath.slice(2)), 'utf8')
+  const escapedName = manifest.name.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+  const row = new RegExp(
+    `^[ \\t]+-[ \\t]+id:[ \\t]*${escapedName}[ \\t]*\\r?\\n^[ \\t]+name:[ \\t]*${escapedName}[ \\t]*$`,
+    'mu',
+  )
+  if (!row.test(patch)) fail(`bundle patch must insert the ${manifest.name} package entry`)
+}
+
+if (manifest.dsh?.client?.platform !== 'web') fail('dsh.client.platform must be web')
+
+if (failures.length > 0) {
+  console.error('Package contract verification failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exitCode = 1
+} else {
+  console.log(`Package contract verified for ${manifest.name}@${manifest.version}`)
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -17,7 +17,10 @@ function requireFile(label, relativePath) {
     return
   }
   const path = relativePath.replace(/^\.\//u, '')
-  if (!existsSync(join(root, path))) fail(`${label} is missing: ${relativePath}`)
+  const absolutePath = join(root, path)
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${label} is missing or is not a file: ${relativePath}`)
+  }
 }
 
 function requireExport(target, condition) {

--- a/tests/polish.test.ts
+++ b/tests/polish.test.ts
@@ -760,6 +760,18 @@ describe('PolishService', () => {
     expect(dispose).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps Host cleanup idempotent when the plugin scope is disposed twice', async () => {
+    const dispose = vi.mocked(disposeWhisperRuntime)
+    dispose.mockClear()
+
+    const context = createContext({})
+    const fiber = await context.plugin(PolishService)
+    await fiber.dispose()
+    await fiber.dispose()
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
   it('sanitizes and caps Whisper model state errors', async () => {
     const context = createContext()
     const fiber = await context.plugin(PolishService)


### PR DESCRIPTION
## Summary

- declare the supported Node.js engine range in the npm package metadata
- verify the built package contract during prepack, including exports, the DSH bundle patch, and the web client manifest
- document DSH Plugin Market install, update, and uninstall behavior in both README files
- add a dynamic npm version badge and a Host cleanup idempotence regression test

The uninstall behavior intentionally preserves dsh-ears settings, cloud API keys, and downloaded Whisper models for reinstall reuse. Host updates still require a dsh restart, matching the market lifecycle.

## Validation

- pnpm check
- pnpm test
- pnpm build
- pnpm verify:package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added npm version information and a link to the package.
  * Clarified that plugins can be installed, updated, and removed through DSH Plugin Market in Settings.

* **Chores**
  * Updated supported Node.js versions.
  * Added automated checks to verify package contents and configuration before publishing.

* **Bug Fixes**
  * Prevented duplicate cleanup when the same plugin scope is disposed multiple times, improving plugin stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->