### PR TITLE
chore(ci): ignore @types/node major updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # engines declares ^22.19.0 || >=24.0.0; typings from newer Node lines
+      # would let type checking admit APIs no supported runtime has. Minor and
+      # patch updates keep tracking the 22.x line; move the ignore manually
+      # when the supported range changes.
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot proposed @types/node 26.3.0 (#34), but `engines` declares `^22.19.0 || >=24.0.0`. Typings from a newer Node line would let type checking admit APIs that no supported runtime provides, so this ignores the package and keeps the 22.x typings line, bumped manually together with the engines range.

Closes #34 once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated updates for the Node.js type definitions are now managed manually, with supported Node.js versions and update guidance documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->