### PR TITLE
fix(client): prevent realtime ASR stop stalls

### DIFF
--- a/src/asr/deepgram-asr.ts
+++ b/src/asr/deepgram-asr.ts
@@ -9,7 +9,6 @@ export const DEEPGRAM_DEFAULT_MODEL = 'nova-3'
 export const DEEPGRAM_RECORDING_TIMEOUT_MS = 120_000
 export const DEEPGRAM_REALTIME_OPEN_TIMEOUT_MS = 15_000
 export const DEEPGRAM_REALTIME_FINISH_TIMEOUT_MS = 5_000
-export const DEEPGRAM_REALTIME_MESSAGE_GRACE_MS = 5
 const DEEPGRAM_MAX_RESPONSE_BYTES = 1 * 1024 * 1024
 
 export interface DeepgramRecordingAsrOptions {
@@ -252,7 +251,6 @@ export class DeepgramRealtimeAsrSession {
   private completedSentences: string[] = []
   private interimSentence = ''
   private transcript = ''
-  private messageVersion = 0
   private lastError: unknown
   private detached = false
   private readonly waiters = new Set<() => void>()
@@ -297,22 +295,19 @@ export class DeepgramRealtimeAsrSession {
   }
 
   async sendAudio(audio: Uint8Array, signal: AbortSignal = this.options.signal ?? new AbortController().signal): Promise<DeepgramRealtimeTranscript> {
-    if (audio.byteLength === 0) return this.snapshot()
     signal.throwIfAborted()
+    if (this.lastError !== undefined) throw this.lastError
+    if (audio.byteLength === 0) return this.snapshot()
     const socket = this.requireSocket()
     if (!this.opened || this.ended || this.closed) {
       throw new EarsError(EARS_ERROR_CODES.asrUnexpected, 'Deepgram realtime recognition is not active')
     }
-    const version = this.messageVersion
     const payload = audio.byteOffset === 0 && audio.byteLength === audio.buffer.byteLength
       ? audio
       : audio.slice()
     socket.send(payload)
-    await this.waitFor(() => this.messageVersion > version || this.lastError !== undefined || this.closed, DEEPGRAM_REALTIME_MESSAGE_GRACE_MS, signal)
-    if (this.lastError !== undefined) throw this.lastError
-    if (this.closed && this.messageVersion === version) {
-      throw new EarsError(EARS_ERROR_CODES.asrHttpFailed, 'Deepgram realtime recognition connection closed')
-    }
+    // Gateway responses update the snapshot asynchronously. Audio delivery is
+    // complete once the ordered frame enters the WebSocket send queue.
     return this.snapshot()
   }
 
@@ -320,6 +315,7 @@ export class DeepgramRealtimeAsrSession {
     try {
       signal.throwIfAborted()
       if (this.final) return this.transcript.trim()
+      if (this.lastError !== undefined) throw this.lastError
       const socket = this.requireSocket()
       if (!this.ended) {
         this.ended = true
@@ -403,7 +399,6 @@ export class DeepgramRealtimeAsrSession {
         this.interimSentence = altText
       }
       this.rebuildTranscript()
-      this.messageVersion += 1
       this.notifyWaiters()
     }
   }

--- a/src/asr/tencent-cloud-asr.ts
+++ b/src/asr/tencent-cloud-asr.ts
@@ -14,7 +14,6 @@ const RECORDING_TIMEOUT_MS = 120_000
 const POLL_INTERVAL_MS = 500
 const REALTIME_OPEN_TIMEOUT_MS = 15_000
 const REALTIME_FINISH_TIMEOUT_MS = 30_000
-const REALTIME_MESSAGE_GRACE_MS = 120
 const TENCENT_VOICE_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
 export interface TencentRecordingAsrOptions {
@@ -213,7 +212,6 @@ export class TencentRealtimeAsrSession {
   private transcript = ''
   private interim: { id: number; text: string } | undefined
   private readonly stableSentences = new Map<number, string>()
-  private messageVersion = 0
   private lastError: EarsError | undefined
   private readonly messageWaiters = new Set<() => void>()
 
@@ -253,15 +251,14 @@ export class TencentRealtimeAsrSession {
   }
 
   async sendAudio(audio: Uint8Array, signal: AbortSignal = this.options.signal ?? new AbortController().signal): Promise<TencentRealtimeTranscript> {
-    if (audio.byteLength === 0) return this.snapshot()
     signal.throwIfAborted()
+    if (this.lastError !== undefined) throw this.lastError
+    if (audio.byteLength === 0) return this.snapshot()
     const socket = this.requireSocket()
     if (!this.opened || this.ended || this.closed) throw new EarsError(EARS_ERROR_CODES.asrUnexpected, 'Tencent Cloud realtime recognition is not active')
-    const version = this.messageVersion
     socket.send(audio)
-    await this.waitFor(() => this.messageVersion > version || this.lastError !== undefined || this.closed, REALTIME_MESSAGE_GRACE_MS, signal)
-    if (this.lastError !== undefined) throw this.lastError
-    if (this.closed && this.messageVersion === version) throw new EarsError(EARS_ERROR_CODES.asrHttpFailed, 'Tencent Cloud realtime recognition connection closed')
+    // Gateway responses update the snapshot asynchronously. Audio delivery is
+    // complete once the ordered frame enters the WebSocket send queue.
     return this.snapshot()
   }
 
@@ -269,6 +266,7 @@ export class TencentRealtimeAsrSession {
     try {
       signal.throwIfAborted()
       if (this.final) return this.transcript.trim()
+      if (this.lastError !== undefined) throw this.lastError
       const socket = this.requireSocket()
       if (!this.ended) {
         this.ended = true
@@ -364,7 +362,6 @@ export class TencentRealtimeAsrSession {
     }
     if (numericValue(parsed.final) === 1) this.final = true
     this.opened = true
-    this.messageVersion += 1
     this.notifyWaiters()
   }
 

--- a/src/asr/volcengine-asr.ts
+++ b/src/asr/volcengine-asr.ts
@@ -15,7 +15,6 @@ export const VOLCENGINE_STATUS_PROCESSING = '20000001'
 export const VOLCENGINE_STATUS_NO_SPEECH = '20000003'
 export const VOLCENGINE_REALTIME_OPEN_TIMEOUT_MS = 15_000
 export const VOLCENGINE_REALTIME_FINISH_TIMEOUT_MS = 30_000
-export const VOLCENGINE_REALTIME_MESSAGE_GRACE_MS = 120
 const VOLCENGINE_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 const VOLCENGINE_SAMPLE_RATE = 16000
 /** End-of-stream marker: a short silence chunk carries the negative-sequence last flag. */
@@ -382,7 +381,6 @@ export class VolcengineRealtimeAsrSession {
   private final = false
   private transcript = ''
   private sequence = 1
-  private messageVersion = 0
   private lastError: EarsError | undefined
   private readonly messageWaiters = new Set<() => void>()
 
@@ -417,16 +415,15 @@ export class VolcengineRealtimeAsrSession {
   }
 
   async sendAudio(audio: Uint8Array, signal: AbortSignal = this.options.signal ?? new AbortController().signal): Promise<VolcengineRealtimeTranscript> {
-    if (audio.byteLength === 0) return this.snapshot()
     signal.throwIfAborted()
+    if (this.lastError !== undefined) throw this.lastError
+    if (audio.byteLength === 0) return this.snapshot()
     const socket = this.requireSocket()
     if (!this.opened || this.ended || this.closed) throw new EarsError(EARS_ERROR_CODES.asrUnexpected, 'Volcano Engine realtime recognition is not active')
-    const version = this.messageVersion
     socket.send(volcengineAudioRequestFrame(this.sequence, audio, false))
     this.sequence += 1
-    await this.waitFor(() => this.messageVersion > version || this.lastError !== undefined || this.closed, VOLCENGINE_REALTIME_MESSAGE_GRACE_MS, signal)
-    if (this.lastError !== undefined) throw this.lastError
-    if (this.closed && this.messageVersion === version) throw new EarsError(EARS_ERROR_CODES.asrHttpFailed, 'Volcano Engine realtime recognition connection closed')
+    // Gateway responses update the snapshot asynchronously. Audio delivery is
+    // complete once the ordered frame enters the WebSocket send queue.
     return this.snapshot()
   }
 
@@ -434,6 +431,7 @@ export class VolcengineRealtimeAsrSession {
     try {
       signal.throwIfAborted()
       if (this.final) return this.transcript.trim()
+      if (this.lastError !== undefined) throw this.lastError
       const socket = this.requireSocket()
       if (!this.ended) {
         this.ended = true
@@ -517,7 +515,6 @@ export class VolcengineRealtimeAsrSession {
     }
     if (frame.payloadMsg !== undefined) this.applyResult(frame.payloadMsg)
     if (frame.isLastPackage) this.final = true
-    this.messageVersion += 1
     this.notifyWaiters()
   }
 

--- a/src/client/MicrophoneButton.tsx
+++ b/src/client/MicrophoneButton.tsx
@@ -15,7 +15,7 @@ import { base64ByteLength, classifyVoiceFailure, failureMessage, isTrivialRecord
 import { commitTranscript, updateDraft } from './voice-flow.js'
 import { matchesShortcut } from '../shortcut.js'
 import { fallbackTranslate, localizedErrorText, type Translate } from './settings-locale.js'
-import { resolveCaptureBackend, isSupersededMediaCapture, shouldAbandonPendingCapture, webSpeechCommittedTranscript } from './voice-capture.js'
+import { resolveCaptureBackend, isSupersededMediaCapture, reuseInFlightPromise, shouldAbandonPendingCapture, webSpeechCommittedTranscript } from './voice-capture.js'
 import { micUnavailableReason, type MicUnavailableReason } from './mic-availability.js'
 import type { BackendHook, WhisperModelHook } from './settings-controller.js'
 import { playClick, resumeSounds, retainSounds } from './sounds.js'
@@ -59,6 +59,7 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
   const mediaStartGenerationRef = useRef(0)
   const mediaBackendRef = useRef<MediaCaptureBackend | null>(null)
   const transcribeAbortRef = useRef<AbortController | null>(null)
+  const realtimeStopPromiseRef = useRef<{ key: string; promise: Promise<void> } | null>(null)
   const polishAbortRef = useRef<AbortController | null>(null)
   const recordingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const stopRecordingRef = useRef<(() => void | Promise<void>) | null>(null)
@@ -122,7 +123,9 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
       mediaStartCancelledRef.current = true
       realtimeStartAbortRef.current?.abort()
       realtimeStartAbortRef.current = null
-      realtimeCaptureRef.current?.abort()
+      const realtimeCapture = realtimeCaptureRef.current
+      realtimeCaptureRef.current = null
+      realtimeCapture?.abort()
       const sessionId = realtimeRemoteSessionIdRef.current
       realtimeRemoteSessionIdRef.current = null
       if (sessionId !== null) void remote.cancelRealtime(sessionId)
@@ -318,59 +321,61 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
     }
   }
 
-  const stopRealtimeRecording = async () => {
+  const stopRealtimeRecording = () => {
     const capture = realtimeCaptureRef.current
     const sessionId = realtimeRemoteSessionIdRef.current
-    if (capture === null || sessionId === null) return
-    playToggleClick(settingsRef.current, 0.4)
-    levelMonitorRef.current?.stop()
-    levelMonitorRef.current = null
-    const controller = new AbortController()
-    transcribeAbortRef.current = controller
-    const epoch = voiceSession.captureEpoch()
-    setState('transcribing')
-    try {
-      await capture.stop()
-      if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
-      const result = await remote.finishRealtime(sessionId, controller.signal)
-      if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
-      if (!result.ok) {
-        applyVoiceFailure(voiceSession, 'asr', result.error)
-        return
+    if (capture === null || sessionId === null) return Promise.resolve()
+    return reuseInFlightPromise(realtimeStopPromiseRef, sessionId, async () => {
+      playToggleClick(settingsRef.current, 0.4)
+      levelMonitorRef.current?.stop()
+      levelMonitorRef.current = null
+      const controller = new AbortController()
+      transcribeAbortRef.current = controller
+      const epoch = voiceSession.captureEpoch()
+      setState('transcribing')
+      try {
+        await capture.stop()
+        if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
+        const result = await remote.finishRealtime(sessionId, controller.signal)
+        if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
+        if (!result.ok) {
+          applyVoiceFailure(voiceSession, 'asr', result.error)
+          return
+        }
+        if (result.value.status === 'error') {
+          applyVoiceFailure(voiceSession, 'asr', result.value)
+          return
+        }
+        const transcript = result.value.text.trim()
+        if (transcript === '') {
+          setState('idle')
+          return
+        }
+        const baseDraft = realtimeBaseDraftRef.current
+        updateDraft(baseDraft, transcript, latestDraftRef, actionsRef)
+        commitTranscript({
+          transcript,
+          baseDraft,
+          expectedDraft: latestDraftRef.current,
+          requireUnchanged: true,
+          transcriptAlreadyApplied: true,
+          settings: settingsRef.current,
+          remote,
+          setState,
+          latestDraftRef,
+          actionsRef,
+          polishAbortRef,
+          isCurrent: () => voiceSession.isCurrentEpoch(epoch)
+        })
+      } catch (error) {
+        if (mountedRef.current && !controller.signal.aborted) applyVoiceFailure(voiceSession, 'asr', error)
+      } finally {
+        if (realtimeCaptureRef.current === capture) realtimeCaptureRef.current = null
+        if (realtimeRemoteSessionIdRef.current === sessionId) realtimeRemoteSessionIdRef.current = null
+        if (transcribeAbortRef.current === controller) transcribeAbortRef.current = null
+        void remote.cancelRealtime(sessionId)
       }
-      if (result.value.status === 'error') {
-        applyVoiceFailure(voiceSession, 'asr', result.value)
-        return
-      }
-      const transcript = result.value.text.trim()
-      if (transcript === '') {
-        setState('idle')
-        return
-      }
-      const baseDraft = realtimeBaseDraftRef.current
-      updateDraft(baseDraft, transcript, latestDraftRef, actionsRef)
-      commitTranscript({
-        transcript,
-        baseDraft,
-        expectedDraft: latestDraftRef.current,
-        requireUnchanged: true,
-        transcriptAlreadyApplied: true,
-        settings: settingsRef.current,
-        remote,
-        setState,
-        latestDraftRef,
-        actionsRef,
-        polishAbortRef,
-        isCurrent: () => voiceSession.isCurrentEpoch(epoch)
-      })
-    } catch (error) {
-      if (mountedRef.current && !controller.signal.aborted) applyVoiceFailure(voiceSession, 'asr', error)
-    } finally {
-      if (realtimeCaptureRef.current === capture) realtimeCaptureRef.current = null
-      if (realtimeRemoteSessionIdRef.current === sessionId) realtimeRemoteSessionIdRef.current = null
-      if (transcribeAbortRef.current === controller) transcribeAbortRef.current = null
-      void remote.cancelRealtime(sessionId)
-    }
+    })
   }
 
   const startRealtimeRecording = async () => {

--- a/src/client/MicrophoneButton.tsx
+++ b/src/client/MicrophoneButton.tsx
@@ -323,17 +323,15 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
     const sessionId = realtimeRemoteSessionIdRef.current
     if (capture === null || sessionId === null) return
     playToggleClick(settingsRef.current, 0.4)
-    realtimeCaptureRef.current = null
-    realtimeRemoteSessionIdRef.current = null
     levelMonitorRef.current?.stop()
     levelMonitorRef.current = null
     const controller = new AbortController()
     transcribeAbortRef.current = controller
     const epoch = voiceSession.captureEpoch()
+    setState('transcribing')
     try {
       await capture.stop()
       if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
-      setState('transcribing')
       const result = await remote.finishRealtime(sessionId, controller.signal)
       if (!mountedRef.current || controller.signal.aborted || !voiceSession.isCurrentEpoch(epoch)) return
       if (!result.ok) {
@@ -368,6 +366,8 @@ export function MicrophoneButton({ input, inputActions, remote, useEarsSettings,
     } catch (error) {
       if (mountedRef.current && !controller.signal.aborted) applyVoiceFailure(voiceSession, 'asr', error)
     } finally {
+      if (realtimeCaptureRef.current === capture) realtimeCaptureRef.current = null
+      if (realtimeRemoteSessionIdRef.current === sessionId) realtimeRemoteSessionIdRef.current = null
       if (transcribeAbortRef.current === controller) transcribeAbortRef.current = null
       void remote.cancelRealtime(sessionId)
     }

--- a/src/client/realtime-audio-capture.ts
+++ b/src/client/realtime-audio-capture.ts
@@ -29,13 +29,11 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
   private readonly source: MediaStreamAudioSourceNode
   private readonly processor: ScriptProcessorNode
   private readonly sink: GainNode
-  // Provider adapters send a packet before waiting for its response. Keep
-  // packet deliveries independent so a slow response cannot stall capture;
-  // stop() still awaits every delivery before the caller sends the end marker.
-  private readonly deliveries = new Set<Promise<void>>()
+  private queue = Promise.resolve()
   private onChunk: ((audioBase64: string) => Promise<void>) | undefined
   private pendingPcm = new Uint8Array()
   private resamplePhase = 0
+  private deliveryGeneration = 0
   private closed = false
   private failure: unknown
 
@@ -100,7 +98,7 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
     this.sink.disconnect()
     stopTracks(this.stream)
     try {
-      await Promise.all([...this.deliveries])
+      await this.queue
       if (this.failure !== undefined) throw this.failure
     } finally {
       await this.context.close()
@@ -108,6 +106,7 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
   }
 
   abort(): void {
+    this.deliveryGeneration += 1
     if (this.closed) return
     this.closed = true
     this.onChunk = undefined
@@ -134,14 +133,13 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
   }
 
   private enqueueChunk(callback: (audioBase64: string) => Promise<void>, pcm: Uint8Array): void {
-    const delivery = (async () => {
-      if (this.failure !== undefined) return
+    const generation = this.deliveryGeneration
+    this.queue = this.queue.then(async () => {
+      if (generation !== this.deliveryGeneration || this.failure !== undefined) return
       await deliverChunk(callback, bytesToBase64(pcm))
-    })().catch((error) => {
+    }).catch((error) => {
       this.failure ??= error
     })
-    this.deliveries.add(delivery)
-    void delivery.finally(() => this.deliveries.delete(delivery))
   }
 }
 

--- a/src/client/realtime-audio-capture.ts
+++ b/src/client/realtime-audio-capture.ts
@@ -29,11 +29,13 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
   private readonly source: MediaStreamAudioSourceNode
   private readonly processor: ScriptProcessorNode
   private readonly sink: GainNode
-  private queue = Promise.resolve()
+  // Provider adapters send a packet before waiting for its response. Keep
+  // packet deliveries independent so a slow response cannot stall capture;
+  // stop() still awaits every delivery before the caller sends the end marker.
+  private readonly deliveries = new Set<Promise<void>>()
   private onChunk: ((audioBase64: string) => Promise<void>) | undefined
   private pendingPcm = new Uint8Array()
   private resamplePhase = 0
-  private deliveryGeneration = 0
   private closed = false
   private failure: unknown
 
@@ -98,7 +100,7 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
     this.sink.disconnect()
     stopTracks(this.stream)
     try {
-      await this.queue
+      await Promise.all([...this.deliveries])
       if (this.failure !== undefined) throw this.failure
     } finally {
       await this.context.close()
@@ -107,7 +109,6 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
 
   abort(): void {
     if (this.closed) return
-    this.deliveryGeneration += 1
     this.closed = true
     this.onChunk = undefined
     this.pendingPcm = new Uint8Array()
@@ -133,13 +134,14 @@ export class RealtimeAudioCaptureSession implements RealtimeAudioCapture {
   }
 
   private enqueueChunk(callback: (audioBase64: string) => Promise<void>, pcm: Uint8Array): void {
-    const generation = this.deliveryGeneration
-    this.queue = this.queue.then(async () => {
-      if (generation !== this.deliveryGeneration || this.failure !== undefined) return
+    const delivery = (async () => {
+      if (this.failure !== undefined) return
       await deliverChunk(callback, bytesToBase64(pcm))
-    }).catch((error) => {
+    })().catch((error) => {
       this.failure ??= error
     })
+    this.deliveries.add(delivery)
+    void delivery.finally(() => this.deliveries.delete(delivery))
   }
 }
 

--- a/src/client/voice-capture.ts
+++ b/src/client/voice-capture.ts
@@ -41,6 +41,23 @@ export function shouldAbandonPendingCapture(mounted: boolean, cancelled: boolean
   return !mounted || cancelled
 }
 
+/** Reuse an asynchronous operation while the same keyed operation is in flight. */
+export function reuseInFlightPromise<TKey, TResult>(
+  inFlight: { current: { key: TKey; promise: Promise<TResult> } | null },
+  key: TKey,
+  operation: () => Promise<TResult>
+): Promise<TResult> {
+  const current = inFlight.current
+  if (current !== null && Object.is(current.key, key)) return current.promise
+  const promise = operation()
+  inFlight.current = { key, promise }
+  const clear = () => {
+    if (inFlight.current?.promise === promise) inFlight.current = null
+  }
+  void promise.then(clear, clear)
+  return promise
+}
+
 /** Check whether a media capture was superseded by a newer start generation. */
 export function isSupersededMediaCapture(latestGeneration: number, generation: number): boolean {
   return latestGeneration !== generation

--- a/tests/deepgram-asr.test.ts
+++ b/tests/deepgram-asr.test.ts
@@ -346,11 +346,11 @@ describe('DeepgramRealtimeAsrSession', () => {
     expect(socket).toBeDefined()
     expect(passedProtocols).toEqual(['token', 'test_key'])
 
-    // Send audio chunk
+    // Sending completes after the ordered frame enters the WebSocket queue;
+    // recognition responses update the snapshot independently.
     const pcm = new Uint8Array([0, 1, 0, 2])
-    const sendPromise = session.sendAudio(pcm)
+    await expect(session.sendAudio(pcm)).resolves.toEqual({ text: '', final: false })
 
-    // Simulate Deepgram results message (interim)
     socket?.emit('message', {
       data: JSON.stringify({
         type: 'Results',
@@ -358,10 +358,7 @@ describe('DeepgramRealtimeAsrSession', () => {
         channel: { alternatives: [{ transcript: 'hello' }] }
       })
     })
-
-    const interim = await sendPromise
-    expect(interim.text).toBe('hello')
-    expect(interim.final).toBe(false)
+    expect(session.snapshot()).toEqual({ text: 'hello', final: false })
 
     // Simulate final result
     socket?.emit('message', {
@@ -393,6 +390,27 @@ describe('DeepgramRealtimeAsrSession', () => {
 
     await expect(session.open()).rejects.toMatchObject({ code: EARS_ERROR_CODES.asrServiceUnavailable })
     expect(webSocketFactory).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an asynchronous stream error on the next operation', async () => {
+    let socket: MockDeepgramWebSocket | undefined
+    const session = new DeepgramRealtimeAsrSession({
+      apiKey: 'test_key',
+      webSocketFactory: () => {
+        socket = new MockDeepgramWebSocket()
+        setTimeout(() => socket?.emit('open'), 0)
+        return socket
+      }
+    })
+
+    await session.open()
+    await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toEqual({ text: '', final: false })
+    socket?.emit('message', {
+      data: JSON.stringify({ err_code: 'STREAM_ERROR', err_msg: 'stream failed' })
+    })
+    await expect(session.sendAudio(new Uint8Array([3, 4]))).rejects.toMatchObject({
+      code: EARS_ERROR_CODES.asrHttpFailed
+    })
   })
 
   it('rejects on invalid auth error message from socket', async () => {

--- a/tests/realtime-audio-capture.test.ts
+++ b/tests/realtime-audio-capture.test.ts
@@ -171,42 +171,7 @@ describe('RealtimeAudioCaptureSession', () => {
     expect(decoded).toHaveLength(1_024)
   })
 
-  it('aborts capture without waiting for in-flight deliveries', async () => {
-    const stream = new FakeStream()
-    const context = new FakeAudioContext()
-    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
-    vi.stubGlobal('AudioContext', class extends FakeAudioContext {
-      constructor() {
-        super()
-        Object.assign(this, context)
-      }
-    })
-
-    const session = await RealtimeAudioCaptureSession.create()
-    const chunks: string[] = []
-    let releaseDeliveries!: () => void
-    const deliveries = new Promise<void>((resolve) => {
-      releaseDeliveries = resolve
-    })
-    session.start(async (chunk) => {
-      chunks.push(chunk)
-      await deliveries
-    })
-    emitAudio(context, samplesOf(640, 0.25))
-    emitAudio(context, samplesOf(640, -0.25))
-
-    await Promise.resolve()
-    expect(chunks).toHaveLength(2)
-    session.abort()
-    releaseDeliveries()
-    await new Promise<void>((resolve) => setTimeout(resolve, 0))
-
-    expect(chunks).toHaveLength(2)
-    expect(stream.track.stop).toHaveBeenCalledOnce()
-    expect(context.close).toHaveBeenCalledOnce()
-  })
-
-  it('delivers chunks concurrently but waits for all deliveries before closing', async () => {
+  it('drops queued chunks after aborting the capture session', async () => {
     const stream = new FakeStream()
     const context = new FakeAudioContext()
     vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
@@ -231,14 +196,83 @@ describe('RealtimeAudioCaptureSession', () => {
     emitAudio(context, samplesOf(640, -0.25))
 
     await Promise.resolve()
-    expect(chunks).toHaveLength(2)
+    expect(chunks).toHaveLength(1)
+    session.abort()
+    releaseFirst()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+    expect(chunks).toHaveLength(1)
+    expect(stream.track.stop).toHaveBeenCalledOnce()
+    expect(context.close).toHaveBeenCalledOnce()
+  })
+
+  it('drops queued chunks when abort follows a pending stop', async () => {
+    const stream = new FakeStream()
+    const context = new FakeAudioContext()
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
+    vi.stubGlobal('AudioContext', class extends FakeAudioContext {
+      constructor() {
+        super()
+        Object.assign(this, context)
+      }
+    })
+
+    const session = await RealtimeAudioCaptureSession.create()
+    const chunks: string[] = []
+    let releaseFirst!: () => void
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    session.start(async (chunk) => {
+      chunks.push(chunk)
+      if (chunks.length === 1) await first
+    })
+    emitAudio(context, samplesOf(640, 0.25))
+    emitAudio(context, samplesOf(640, -0.25))
 
     const stopping = session.stop()
     await Promise.resolve()
+    expect(chunks).toHaveLength(1)
+    session.abort()
+    releaseFirst()
+    await stopping
+
+    expect(chunks).toHaveLength(1)
+    expect(context.close).toHaveBeenCalledOnce()
+  })
+
+  it('waits for queued chunks before closing the audio context', async () => {
+    const stream = new FakeStream()
+    const context = new FakeAudioContext()
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
+    vi.stubGlobal('AudioContext', class extends FakeAudioContext {
+      constructor() {
+        super()
+        Object.assign(this, context)
+      }
+    })
+
+    const session = await RealtimeAudioCaptureSession.create()
+    const chunks: string[] = []
+    let releaseFirst!: () => void
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    session.start(async (chunk) => {
+      chunks.push(chunk)
+      if (chunks.length === 1) await first
+    })
+    emitAudio(context, samplesOf(640, 0.25))
+    emitAudio(context, samplesOf(640, -0.25))
+
+    const stopping = session.stop()
+    await Promise.resolve()
+    expect(chunks).toHaveLength(1)
     expect(context.close).not.toHaveBeenCalled()
 
     releaseFirst()
     await stopping
+    expect(chunks).toHaveLength(2)
     expect(context.close).toHaveBeenCalledOnce()
   })
 

--- a/tests/realtime-audio-capture.test.ts
+++ b/tests/realtime-audio-capture.test.ts
@@ -171,7 +171,7 @@ describe('RealtimeAudioCaptureSession', () => {
     expect(decoded).toHaveLength(1_024)
   })
 
-  it('drops queued chunks after aborting the capture session', async () => {
+  it('aborts capture without waiting for in-flight deliveries', async () => {
     const stream = new FakeStream()
     const context = new FakeAudioContext()
     vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
@@ -184,29 +184,29 @@ describe('RealtimeAudioCaptureSession', () => {
 
     const session = await RealtimeAudioCaptureSession.create()
     const chunks: string[] = []
-    let releaseFirst!: () => void
-    const first = new Promise<void>((resolve) => {
-      releaseFirst = resolve
+    let releaseDeliveries!: () => void
+    const deliveries = new Promise<void>((resolve) => {
+      releaseDeliveries = resolve
     })
     session.start(async (chunk) => {
       chunks.push(chunk)
-      if (chunks.length === 1) await first
+      await deliveries
     })
     emitAudio(context, samplesOf(640, 0.25))
     emitAudio(context, samplesOf(640, -0.25))
 
     await Promise.resolve()
-    expect(chunks).toHaveLength(1)
+    expect(chunks).toHaveLength(2)
     session.abort()
-    releaseFirst()
+    releaseDeliveries()
     await new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-    expect(chunks).toHaveLength(1)
+    expect(chunks).toHaveLength(2)
     expect(stream.track.stop).toHaveBeenCalledOnce()
     expect(context.close).toHaveBeenCalledOnce()
   })
 
-  it('waits for queued chunks before closing the audio context', async () => {
+  it('delivers chunks concurrently but waits for all deliveries before closing', async () => {
     const stream = new FakeStream()
     const context = new FakeAudioContext()
     vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } })
@@ -230,14 +230,15 @@ describe('RealtimeAudioCaptureSession', () => {
     emitAudio(context, samplesOf(640, 0.25))
     emitAudio(context, samplesOf(640, -0.25))
 
+    await Promise.resolve()
+    expect(chunks).toHaveLength(2)
+
     const stopping = session.stop()
     await Promise.resolve()
-    expect(chunks).toHaveLength(1)
     expect(context.close).not.toHaveBeenCalled()
 
     releaseFirst()
     await stopping
-    expect(chunks).toHaveLength(2)
     expect(context.close).toHaveBeenCalledOnce()
   })
 

--- a/tests/tencent-cloud-asr.test.ts
+++ b/tests/tencent-cloud-asr.test.ts
@@ -238,9 +238,9 @@ describe('Tencent Cloud realtime recognition', () => {
     expect(voiceId).toMatch(/^[A-Za-z0-9]{16}$/)
   })
 
-  it('rejects malformed response codes', async () => {
+  it('rejects malformed response codes on the next operation', async () => {
     for (const code of [undefined, null, true, '', 'not-a-number', {}]) {
-      const socket = new FakeWebSocket(JSON.stringify({ code, result: { voice_text_str: '你好', index: 0, slice_type: 2 } }))
+      const socket = new FakeWebSocket(undefined, false)
       const session = new TencentRealtimeAsrSession({
         appId: '1250000000',
         secretId: 'AKIDexample',
@@ -249,11 +249,13 @@ describe('Tencent Cloud realtime recognition', () => {
         webSocketFactory: () => socket
       })
       await session.open()
-      await expect(session.sendAudio(new Uint8Array([1, 2]))).rejects.toMatchObject({ code: EARS_ERROR_CODES.asrInvalidResponse })
+      await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toEqual({ text: '', final: false })
+      socket.emit('message', { data: JSON.stringify({ code, result: { voice_text_str: '你好', index: 0, slice_type: 2 } }) })
+      await expect(session.sendAudio(new Uint8Array([3, 4]))).rejects.toMatchObject({ code: EARS_ERROR_CODES.asrInvalidResponse })
     }
   })
 
-  it('rejects malformed realtime result payloads', async () => {
+  it('rejects malformed realtime result payloads on the next operation', async () => {
     for (const result of [
       null,
       {},
@@ -261,7 +263,7 @@ describe('Tencent Cloud realtime recognition', () => {
       { voice_text_str: 1, index: 0, slice_type: 1 },
       { voice_text_str: '你好', index: 'not-a-number', slice_type: 1 }
     ]) {
-      const socket = new FakeWebSocket(JSON.stringify({ code: 0, result }))
+      const socket = new FakeWebSocket(undefined, false)
       const session = new TencentRealtimeAsrSession({
         appId: '1250000000',
         secretId: 'AKIDexample',
@@ -270,11 +272,13 @@ describe('Tencent Cloud realtime recognition', () => {
         webSocketFactory: () => socket
       })
       await session.open()
-      await expect(session.sendAudio(new Uint8Array([1, 2]))).rejects.toMatchObject({ code: EARS_ERROR_CODES.asrInvalidResponse })
+      await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toEqual({ text: '', final: false })
+      socket.emit('message', { data: JSON.stringify({ code: 0, result }) })
+      await expect(session.sendAudio(new Uint8Array([3, 4]))).rejects.toMatchObject({ code: EARS_ERROR_CODES.asrInvalidResponse })
     }
   })
   it('accepts a numeric response code string', async () => {
-    const socket = new FakeWebSocket(JSON.stringify({ code: '0', result: { voice_text_str: '你好', index: 0, slice_type: 2 } }))
+    const socket = new FakeWebSocket(undefined, false)
     const session = new TencentRealtimeAsrSession({
       appId: '1250000000',
       secretId: 'AKIDexample',
@@ -283,7 +287,9 @@ describe('Tencent Cloud realtime recognition', () => {
       webSocketFactory: () => socket
     })
     await session.open()
-    await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toMatchObject({ text: '你好', final: false })
+    await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toEqual({ text: '', final: false })
+    socket.emit('message', { data: JSON.stringify({ code: '0', result: { voice_text_str: '你好', index: 0, slice_type: 2 } }) })
+    expect(session.snapshot()).toEqual({ text: '你好', final: false })
     session.close()
   })
 
@@ -334,7 +340,8 @@ describe('Tencent Cloud realtime recognition', () => {
       webSocketFactory: () => socket
     })
     await session.open()
-    await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toMatchObject({ text: '你好', final: false })
+    await expect(session.sendAudio(new Uint8Array([1, 2]))).resolves.toEqual({ text: '', final: false })
+    await vi.waitFor(() => expect(session.snapshot()).toMatchObject({ text: '你好', final: false }))
     await expect(session.finish()).resolves.toBe('你好')
     expect(socket.sent.some((item) => typeof item === 'string' && item === JSON.stringify({ type: 'end' }))).toBe(true)
     expect(socket.readyState).toBe(3)

--- a/tests/voice-capture.test.ts
+++ b/tests/voice-capture.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   decideMicrophoneClick,
   isSupersededMediaCapture,
+  reuseInFlightPromise,
   resolveCaptureBackend,
   shouldAbandonPendingCapture,
   voiceToggleAction,
@@ -81,6 +82,38 @@ describe('shouldAbandonPendingCapture', () => {
     expect(shouldAbandonPendingCapture(false, false)).toBe(true)
     expect(shouldAbandonPendingCapture(true, true)).toBe(true)
     expect(shouldAbandonPendingCapture(false, true)).toBe(true)
+  })
+})
+
+describe('reuseInFlightPromise', () => {
+  it('reuses the active promise for one key and isolates a later key', async () => {
+    const inFlight: { current: { key: string; promise: Promise<string> } | null } = { current: null }
+    let resolveFirst!: (value: string) => void
+    let resolveNext!: (value: string) => void
+    let operationCalls = 0
+    const firstOperation = () => new Promise<string>((resolve) => {
+      operationCalls += 1
+      resolveFirst = resolve
+    })
+
+    const first = reuseInFlightPromise(inFlight, 'session-1', firstOperation)
+    const second = reuseInFlightPromise(inFlight, 'session-1', firstOperation)
+    expect(second).toBe(first)
+    expect(operationCalls).toBe(1)
+
+    const next = reuseInFlightPromise(inFlight, 'session-2', () => new Promise<string>((resolve) => {
+      operationCalls += 1
+      resolveNext = resolve
+    }))
+    expect(operationCalls).toBe(2)
+
+    resolveFirst('done')
+    await expect(first).resolves.toBe('done')
+    expect(inFlight.current?.key).toBe('session-2')
+
+    resolveNext('next')
+    await expect(next).resolves.toBe('next')
+    expect(inFlight.current).toBeNull()
   })
 })
 

--- a/tests/volcengine-asr.test.ts
+++ b/tests/volcengine-asr.test.ts
@@ -129,7 +129,7 @@ class FakeWebSocket implements VolcengineWebSocket {
     this.listeners.get(type)?.delete(listener)
   }
 
-  private emit(type: string, event: FakeEvent): void {
+  emit(type: string, event: FakeEvent): void {
     for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event)
   }
 }
@@ -351,14 +351,16 @@ describe('Volcano Engine one-way streaming session', () => {
     expect(handshake.payload.request).toMatchObject({ model_name: 'bigmodel' })
     expect(handshake.payload.audio).toMatchObject({ format: 'pcm', language: 'zh-CN' })
 
-    sockets[0]!.queue(successFrame({ audio_info: { duration: 400 }, result: { text: '你好，' } }, 2))
     const first = await session.sendAudio(new Uint8Array([1, 2, 3, 4]))
-    expect(first).toEqual({ text: '你好，', final: false })
+    expect(first).toEqual({ text: '', final: false })
     expect(decodeAudioFrame(sockets[0]!.sent[1]!)).toMatchObject({ messageType: AUDIO_ONLY_REQUEST, sequence: 2 })
+    sockets[0]!.emit('message', { data: successFrame({ audio_info: { duration: 400 }, result: { text: '你好，' } }, 2).buffer })
+    expect(session.snapshot()).toEqual({ text: '你好，', final: false })
 
     sockets[0]!.queue(successFrame({ audio_info: { duration: 800 }, result: { text: '你好，世界' } }, 3))
     const second = await session.sendAudio(new Uint8Array([5, 6, 7, 8]))
-    expect(second.text).toBe('你好，世界')
+    expect(second.text).toBe('你好，')
+    await vi.waitFor(() => expect(session.snapshot().text).toBe('你好，世界'))
 
     sockets[0]!.queue(successFrame({ audio_info: { duration: 900 }, result: { text: '你好，世界' } }, 4, true))
     await expect(session.finish()).resolves.toBe('你好，世界')
@@ -380,11 +382,12 @@ describe('Volcano Engine one-way streaming session', () => {
       webSocketFactory: () => socket
     })
     await session.open()
-    socket.queue(successFrame({ result: { utterances: [
+    await expect(session.sendAudio(new Uint8Array([1]))).resolves.toEqual({ text: '', final: false })
+    socket.emit('message', { data: successFrame({ result: { utterances: [
       { definite: true, text: '第一句' },
       { definite: false, text: '第二' }
-    ] } }, 2))
-    await expect(session.sendAudio(new Uint8Array([1]))).resolves.toEqual({ text: '第一句', final: false })
+    ] } }, 2).buffer })
+    expect(session.snapshot()).toEqual({ text: '第一句', final: false })
   })
 
   it('surfaces a server error frame as a business failure', async () => {
@@ -395,8 +398,9 @@ describe('Volcano Engine one-way streaming session', () => {
       webSocketFactory: () => socket
     })
     await session.open()
-    socket.queue(errorFrame('invalid request'))
-    await expect(session.sendAudio(new Uint8Array([1]))).rejects.toMatchObject({
+    await expect(session.sendAudio(new Uint8Array([1]))).resolves.toEqual({ text: '', final: false })
+    socket.emit('message', { data: errorFrame('invalid request').buffer })
+    await expect(session.finish()).rejects.toMatchObject({
       code: EARS_ERROR_CODES.asrHttpFailed,
       message: expect.stringContaining('invalid request')
     })


### PR DESCRIPTION
## Summary

- preserve ordered FIFO PCM delivery from browser capture to each Host-managed realtime WebSocket
- complete provider audio sends after the ordered frame enters the WebSocket send queue, while asynchronous gateway responses continue updating the live transcript snapshot
- enter the processing state immediately on stop, drain queued audio, and await the provider's terminal result before committing the transcript
- make realtime stop single-flight per session and let discard invalidate queued packets while preserving session-safe cleanup
- cover Volcengine, Tencent Cloud, Deepgram, FIFO drain, cancellation, and repeated-stop behavior with regression tests

Closes #39.

## Verification

- `pnpm check`
- `pnpm test` (547 passed)
- `pnpm build`

Provider protocol behavior is covered by injected WebSocket adapter tests. A credentialed live-provider smoke test was not run for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time transcription state handling while recording stops and transcription completes.
  * Audio chunks now process in order, with pending deliveries completing reliably when recording stops.
  * Canceling a recording now prevents stale audio from being delivered.
  * Improved cleanup behavior when recording sessions are ended or canceled.
  * Prevented newer recording sessions from being affected by cleanup from older sessions.
  * Improved handling and reporting of delayed recognition responses and streaming errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->